### PR TITLE
Feature/7 rooms api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ bin/
 *.iml
 *.ipr
 prayTogether*.properties
-**/wallet/
+**/*wallet/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/gradlew
+++ b/gradlew
@@ -167,7 +167,7 @@ fi
 #   * the main class name
 #   * -classpath
 #   * -D...appname settings
-#   * --module-path (only if needed)
+#   * --model-path (only if needed)
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
 
 # For Cygwin or MSYS, switch paths to Windows format before running java

--- a/src/main/java/site/praytogether/pray_together/config/JpaAuditConfig.java
+++ b/src/main/java/site/praytogether/pray_together/config/JpaAuditConfig.java
@@ -1,0 +1,28 @@
+package site.praytogether.pray_together.config;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import site.praytogether.pray_together.domain.auth.domain.PrayTogetherPrincipal;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+
+  @Bean
+  public AuditorAware<Long> auditorAware() {
+    return () ->
+        Optional.ofNullable(SecurityContextHolder.getContext())
+            .map(SecurityContext::getAuthentication)
+            .filter(Authentication::isAuthenticated)
+            .map(Authentication::getPrincipal)
+            .filter(principal -> principal instanceof PrayTogetherPrincipal)
+            .map(PrayTogetherPrincipal.class::cast)
+            .map(PrayTogetherPrincipal::getId);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/constant/CoreConstant.java
+++ b/src/main/java/site/praytogether/pray_together/constant/CoreConstant.java
@@ -1,0 +1,24 @@
+package site.praytogether.pray_together.constant;
+
+public class CoreConstant {
+  private static final int RDBMS_CHAR_LEN_BYTE = 3;
+
+  public static class MemberConstant {
+    public static final int EMAIL_MAX_LEN = 50 * RDBMS_CHAR_LEN_BYTE;
+    public static final int NAME_MAX_LEN = 20 * RDBMS_CHAR_LEN_BYTE;
+    public static final int PASSWORD_MAX_LEN = 20 * RDBMS_CHAR_LEN_BYTE;
+  }
+
+  public static class RoomConstant {
+    public static final int NAME_MAX_LEN = 50 * RDBMS_CHAR_LEN_BYTE;
+    public static final int DESCRIPTION_MAX_LEN = 255 * RDBMS_CHAR_LEN_BYTE;
+  }
+
+  public static class MemberRoomConstant {
+    public static final int ROLE_MAX_LEN = 10 * RDBMS_CHAR_LEN_BYTE;
+    public static final String DEFAULT_INFINITE_SCROLL_ORDER_BY = "time";
+    public static final String DEFAULT_INFINITE_SCROLL_AFTER = "0";
+    public static final String DEFAULT_INFINITE_SCROLL_DIR = "desc";
+    public static final int ROOMS_INFINITE_SCROLL_SIZE = 10;
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/auth/annotation/PrayTogetherMemberId.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/annotation/PrayTogetherMemberId.java
@@ -1,0 +1,14 @@
+package site.praytogether.pray_together.domain.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(
+    expression = "#this == 'anonymousUser' ? null : id",
+    errorOnInvalidType = true)
+public @interface PrayTogetherMemberId {}

--- a/src/main/java/site/praytogether/pray_together/domain/auth/annotation/PrincipalId.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/annotation/PrincipalId.java
@@ -11,4 +11,4 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @AuthenticationPrincipal(
     expression = "#this == 'anonymousUser' ? null : id",
     errorOnInvalidType = true)
-public @interface PrayTogetherMemberId {}
+public @interface PrincipalId {}

--- a/src/main/java/site/praytogether/pray_together/domain/auth/domain/PrayTogetherPrincipal.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/domain/PrayTogetherPrincipal.java
@@ -1,0 +1,33 @@
+package site.praytogether.pray_together.domain.auth.domain;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@AllArgsConstructor
+@Getter
+public class PrayTogetherPrincipal implements UserDetails {
+
+  private final Long id;
+  private final String email;
+  private final String username; // equals with email
+  private final String password;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return (Collection<? extends GrantedAuthority>) Map.of();
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return email;
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/base/BaseEntity.java
+++ b/src/main/java/site/praytogether/pray_together/domain/base/BaseEntity.java
@@ -1,0 +1,34 @@
+package site.praytogether.pray_together.domain.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_time", updatable = false, columnDefinition = "TIMESTAMP(3)")
+  private Instant createdTime;
+
+  @CreatedBy
+  @Column(name = "created_by")
+  private Long createdBy;
+
+  @LastModifiedDate
+  @Column(name = "updated_time", columnDefinition = "TIMESTAMP(3)")
+  private Instant updatedTime;
+
+  @LastModifiedBy
+  @Column(name = "updated_By")
+  private Long updatedBy;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/base/MessageResponse.java
+++ b/src/main/java/site/praytogether/pray_together/domain/base/MessageResponse.java
@@ -1,0 +1,15 @@
+package site.praytogether.pray_together.domain.base;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MessageResponse {
+  private final String message;
+
+  public static MessageResponse of(String msg) {
+    return new MessageResponse(msg);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member/expcetion/MemberException.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/expcetion/MemberException.java
@@ -1,0 +1,12 @@
+package site.praytogether.pray_together.domain.member.expcetion;
+
+import site.praytogether.pray_together.exception.BaseException;
+import site.praytogether.pray_together.exception.ExceptionField;
+import site.praytogether.pray_together.exception.spec.ExceptionSpec;
+
+public abstract class MemberException extends BaseException {
+
+  protected MemberException(ExceptionSpec spec, Long memberId) {
+    super(spec, ExceptionField.builder().add("memberId", memberId).build());
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member/expcetion/MemberNotFoundException.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/expcetion/MemberNotFoundException.java
@@ -1,0 +1,15 @@
+package site.praytogether.pray_together.domain.member.expcetion;
+
+import site.praytogether.pray_together.exception.spec.MemberExceptionSpec;
+
+public class MemberNotFoundException extends MemberException {
+
+  public MemberNotFoundException(Long memberId) {
+    super(MemberExceptionSpec.MEMBER_NOT_FOUND, memberId);
+  }
+
+  @Override
+  public String getClientMessage() {
+    return "회원 정보를 찾을 수 없습니다.";
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member/model/Member.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/model/Member.java
@@ -1,0 +1,42 @@
+package site.praytogether.pray_together.domain.member.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.praytogether.pray_together.constant.CoreConstant.MemberConstant;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@Table(name = "member")
+@SequenceGenerator(
+    name = "MEMBER_SEQ_GENERATOR",
+    sequenceName = "MEMBER_SEQ",
+    initialValue = 1,
+    allocationSize = 50)
+public class Member extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_SEQ_GENERATOR")
+  private Long id;
+
+  @Column(nullable = false, length = MemberConstant.EMAIL_MAX_LEN, unique = true)
+  private String email;
+
+  @Column(nullable = false, length = MemberConstant.NAME_MAX_LEN, unique = true)
+  private String name;
+
+  @Column(nullable = false, length = MemberConstant.PASSWORD_MAX_LEN)
+  private String password;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member/model/MemberIdName.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/model/MemberIdName.java
@@ -1,0 +1,13 @@
+package site.praytogether.pray_together.domain.member.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberIdName {
+  private final Long id;
+  private final String name;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/repository/MemberRepository.java
@@ -1,0 +1,6 @@
+package site.praytogether.pray_together.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.praytogether.pray_together.domain.member.model.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {}

--- a/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
@@ -1,8 +1,8 @@
 package site.praytogether.pray_together.domain.member.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.member.expcetion.MemberNotFoundException;
 import site.praytogether.pray_together.domain.member.model.Member;
 import site.praytogether.pray_together.domain.member.repository.MemberRepository;
 
@@ -11,11 +11,13 @@ import site.praytogether.pray_together.domain.member.repository.MemberRepository
 public class MemberService {
   private final MemberRepository memberRepository;
 
-  public Optional<Member> getRefIfExist(Long memberId) {
-    if (isExistMember(memberId)) {
-      return Optional.of(memberRepository.getReferenceById(memberId));
-    }
-    return Optional.empty();
+  public Member getRefOrThrow(Long memberId) {
+    validateMemberExists(memberId);
+    return memberRepository.getReferenceById(memberId);
+  }
+
+  public void validateMemberExists(Long memberId) {
+    if (isExistMember(memberId) == false) throw new MemberNotFoundException(memberId);
   }
 
   public boolean isExistMember(Long memberId) {

--- a/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
@@ -1,0 +1,24 @@
+package site.praytogether.pray_together.domain.member.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+  private final MemberRepository memberRepository;
+
+  public Optional<Member> getRefIfExist(Long memberId) {
+    if (isExistMember(memberId)) {
+      return Optional.of(memberRepository.getReferenceById(memberId));
+    }
+    return Optional.empty();
+  }
+
+  public boolean isExistMember(Long memberId) {
+    return memberRepository.existsById(memberId);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/exception/MemberRoomException.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/exception/MemberRoomException.java
@@ -1,0 +1,12 @@
+package site.praytogether.pray_together.domain.member_room.exception;
+
+import site.praytogether.pray_together.exception.BaseException;
+import site.praytogether.pray_together.exception.ExceptionField;
+import site.praytogether.pray_together.exception.spec.ExceptionSpec;
+
+public abstract class MemberRoomException extends BaseException {
+
+  protected MemberRoomException(ExceptionSpec spec, ExceptionField fields) {
+    super(spec, fields);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/exception/MemberRoomNotFoundException.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/exception/MemberRoomNotFoundException.java
@@ -1,0 +1,20 @@
+package site.praytogether.pray_together.domain.member_room.exception;
+
+import site.praytogether.pray_together.exception.ExceptionField;
+import site.praytogether.pray_together.exception.spec.MemberRoomExceptionSpec;
+
+public class MemberRoomNotFoundException extends MemberRoomException {
+
+  public MemberRoomNotFoundException(Long memberId, Long roomId) {
+    this(ExceptionField.builder().add("memberId", memberId).add("roomId", roomId).build());
+  }
+
+  protected MemberRoomNotFoundException(ExceptionField fields) {
+    super(MemberRoomExceptionSpec.MEMBER_ROOM_NOT_FOUND, fields);
+  }
+
+  @Override
+  public String getClientMessage() {
+    return "회원님이 속해있는 방을 찾지 못 했습니다.";
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/model/MemberRoom.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/model/MemberRoom.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.domain.memberroom.model;
+package site.praytogether.pray_together.domain.member_room.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomIdMemberCnt.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomIdMemberCnt.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.domain.memberroom.model;
+package site.praytogether.pray_together.domain.member_room.model;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomIdMemberCount.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomIdMemberCount.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class RoomIdMemberCnt {
+public class RoomIdMemberCount {
   Long roomId;
   Long memberCnt;
 
-  public RoomIdMemberCnt(Long id, Long memberCnt) {
+  public RoomIdMemberCount(Long id, Long memberCnt) {
     this.roomId = id;
     this.memberCnt = memberCnt;
   }

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomInfo.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomInfo.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.domain.memberroom.model;
+package site.praytogether.pray_together.domain.member_room.model;
 
 import java.time.Instant;
 import lombok.AllArgsConstructor;

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
@@ -14,9 +14,18 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   boolean deleteByMember_IdAndRoom_Id(Long memberId, Long roomId);
 
-  List<MemberIdName> findByRoom_Id(Long roomId);
-
   boolean existsByMember_IdAndRoom_Id(Long memberId, Long roomId);
+
+  @Query(
+      """
+      SELECT new site.praytogether.pray_together.domain.member.model.MemberIdName(
+        m.id, m.name
+      )
+      FROM MemberRoom mr
+      JOIN Member m ON m.id = mr.member.id
+      WHERE mr.room.id = :roomId
+""")
+  List<MemberIdName> findMember_IdAndNameByRoom_Id(Long roomId);
 
   @Query(
       """

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
@@ -1,19 +1,21 @@
-package site.praytogether.pray_together.domain.memberroom.repository;
+package site.praytogether.pray_together.domain.member_room.repository;
 
 import java.time.Instant;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import site.praytogether.pray_together.domain.memberroom.model.MemberRoom;
-import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
-import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
+import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
+  boolean deleteByMember_IdAndRoom_Id(Long memberId, Long roomId);
+
   @Query(
       """
-      SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomInfo(
+      SELECT new site.praytogether.pray_together.domain.member_room.model.RoomInfo(
         r.id ,r.name, r.description,mr.createdTime ,mr.isNotification
       )
       FROM MemberRoom  mr
@@ -25,7 +27,7 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   @Query(
       """
-          SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomInfo(
+          SELECT new site.praytogether.pray_together.domain.member_room.model.RoomInfo(
             r.id ,r.name, r.description,mr.createdTime ,mr.isNotification
           )
           FROM MemberRoom  mr
@@ -38,7 +40,7 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   @Query(
       """
-        SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomIdMember(
+        SELECT new site.praytogether.pray_together.domain.member_room.model.RoomIdMember(
         mr.room.id, COUNT(*)
         )
         FROM MemberRoom mr

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
@@ -5,13 +5,18 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import site.praytogether.pray_together.domain.member.model.MemberIdName;
 import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
-import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount;
 import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   boolean deleteByMember_IdAndRoom_Id(Long memberId, Long roomId);
+
+  List<MemberIdName> findByRoom_Id(Long roomId);
+
+  boolean existsByMember_IdAndRoom_Id(Long memberId, Long roomId);
 
   @Query(
       """
@@ -40,7 +45,7 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   @Query(
       """
-        SELECT new site.praytogether.pray_together.domain.member_room.model.RoomIdMember(
+        SELECT new site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount(
         mr.room.id, COUNT(*)
         )
         FROM MemberRoom mr
@@ -48,5 +53,5 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
         GROUP BY mr.room.id
 
 """)
-  List<RoomIdMemberCnt> findMemberCntByIds(List<Long> roomIds);
+  List<RoomIdMemberCount> findMemberCountByIds(List<Long> roomIds);
 }

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.domain.memberroom.service;
+package site.praytogether.pray_together.domain.member_room.service;
 
 import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.DEFAULT_INFINITE_SCROLL_AFTER;
 import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.ROOMS_INFINITE_SCROLL_SIZE;
@@ -12,10 +12,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.member.model.Member;
-import site.praytogether.pray_together.domain.memberroom.model.MemberRoom;
-import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
-import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
-import site.praytogether.pray_together.domain.memberroom.repository.MemberRoomRepository;
+import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
+import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
+import site.praytogether.pray_together.domain.member_room.repository.MemberRoomRepository;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
 import site.praytogether.pray_together.domain.room.model.Room;
 import site.praytogether.pray_together.domain.room.model.RoomRole;
@@ -71,5 +71,9 @@ public class MemberRoomService {
                 roomInfo -> roomInfo,
                 (existing, replacement) -> existing,
                 LinkedHashMap::new));
+  }
+
+  public boolean deleteMemberRoomById(Long memberId, Long roomId) {
+    return memberRoomRepository.deleteByMember_IdAndRoom_Id(memberId, roomId);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -12,8 +12,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member.model.MemberIdName;
+import site.praytogether.pray_together.domain.member_room.exception.MemberRoomNotFoundException;
 import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
-import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount;
 import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
 import site.praytogether.pray_together.domain.member_room.repository.MemberRoomRepository;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
@@ -47,8 +49,8 @@ public class MemberRoomService {
     return convertToOrderedMap(roomInfos);
   }
 
-  public List<RoomIdMemberCnt> fetchRoomMemberCounts(List<Long> roomIds) {
-    return memberRoomRepository.findMemberCntByIds(roomIds);
+  public List<RoomIdMemberCount> fetchRoomMemberCounts(List<Long> roomIds) {
+    return memberRoomRepository.findMemberCountByIds(roomIds);
   }
 
   private List<RoomInfo> fetchRoomsByAfter(Long memberId, RoomScrollRequest scrollRequest) {
@@ -73,7 +75,18 @@ public class MemberRoomService {
                 LinkedHashMap::new));
   }
 
+  @Transactional
   public boolean deleteMemberRoomById(Long memberId, Long roomId) {
     return memberRoomRepository.deleteByMember_IdAndRoom_Id(memberId, roomId);
+  }
+
+  public List<MemberIdName> fetchMembersInRoom(Long roomId) {
+    return memberRoomRepository.findByRoom_Id(roomId);
+  }
+
+  public void validateMemberExistInRoom(Long memberId, Long roomId) {
+    if (memberRoomRepository.existsByMember_IdAndRoom_Id(memberId, roomId) == false) {
+      throw new MemberRoomNotFoundException(memberId, roomId);
+    }
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -81,7 +81,7 @@ public class MemberRoomService {
   }
 
   public List<MemberIdName> fetchMembersInRoom(Long roomId) {
-    return memberRoomRepository.findByRoom_Id(roomId);
+    return memberRoomRepository.findMember_IdAndNameByRoom_Id(roomId);
   }
 
   public void validateMemberExistInRoom(Long memberId, Long roomId) {

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/model/MemberRoom.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/model/MemberRoom.java
@@ -1,0 +1,56 @@
+package site.praytogether.pray_together.domain.memberroom.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.room.model.Room;
+import site.praytogether.pray_together.domain.room.model.RoomRole;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@Table(name = "member_room")
+@SequenceGenerator(
+    name = "MEMBER_ROOM_SEQ_GENERATOR",
+    sequenceName = "MEMBER_ROOM_SEQ",
+    initialValue = 1,
+    allocationSize = 50)
+public class MemberRoom extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_ROOM_SEQ_GENERATOR")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "room_id", nullable = false)
+  private Room room;
+
+  @Column(nullable = false, length = MemberRoomConstant.ROLE_MAX_LEN)
+  @Enumerated(EnumType.STRING)
+  private RoomRole role;
+
+  @Column(name = "is_notification", nullable = false)
+  private boolean isNotification;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/model/RoomIdMemberCnt.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/model/RoomIdMemberCnt.java
@@ -1,0 +1,17 @@
+package site.praytogether.pray_together.domain.memberroom.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomIdMemberCnt {
+  Long roomId;
+  Long memberCnt;
+
+  public RoomIdMemberCnt(Long id, Long memberCnt) {
+    this.roomId = id;
+    this.memberCnt = memberCnt;
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/model/RoomInfo.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/model/RoomInfo.java
@@ -1,0 +1,30 @@
+package site.praytogether.pray_together.domain.memberroom.model;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor()
+@Getter
+public class RoomInfo {
+  private final Long roomId;
+  private final String name;
+  private Long memberCnt;
+  private final String description;
+  private final Instant joinedTime;
+  private final boolean isNotification;
+
+  public RoomInfo(
+      Long id, String name, String description, Instant createdTime, boolean isNotification) {
+    this.roomId = id;
+    this.name = name;
+    this.memberCnt = 0L;
+    this.description = description;
+    this.joinedTime = createdTime;
+    this.isNotification = isNotification;
+  }
+
+  public void setMemberCnt(Long memberCnt) {
+    this.memberCnt = memberCnt;
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/repository/MemberRoomRepository.java
@@ -1,0 +1,50 @@
+package site.praytogether.pray_together.domain.memberroom.repository;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import site.praytogether.pray_together.domain.memberroom.model.MemberRoom;
+import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+
+public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
+
+  @Query(
+      """
+      SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomInfo(
+        r.id ,r.name, r.description,mr.createdTime ,mr.isNotification
+      )
+      FROM MemberRoom  mr
+      JOIN Room  r ON mr.room.id = r.id
+      WHERE mr.member.id = :memberId
+      ORDER BY mr.createdTime DESC
+""")
+  List<RoomInfo> findFirstRoomInfoOrderByJoinedTimeDesc(Long memberId, Pageable pageable);
+
+  @Query(
+      """
+          SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomInfo(
+            r.id ,r.name, r.description,mr.createdTime ,mr.isNotification
+          )
+          FROM MemberRoom  mr
+          JOIN Room  r ON mr.room.id = r.id
+          WHERE mr.member.id = :memberId AND mr.createdTime < :joinedTime
+          ORDER BY mr.createdTime DESC
+    """)
+  List<RoomInfo> findRoomInfoOrderByJoinedTimeDesc(
+      Long memberId, Instant joinedTime, Pageable pageable);
+
+  @Query(
+      """
+        SELECT new site.praytogether.pray_together.domain.memberroom.model.RoomIdMember(
+        mr.room.id, COUNT(*)
+        )
+        FROM MemberRoom mr
+        WHERE mr.id IN :roomIds
+        GROUP BY mr.room.id
+
+""")
+  List<RoomIdMemberCnt> findMemberCntByIds(List<Long> roomIds);
+}

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/service/MemberRoomService.java
@@ -1,0 +1,59 @@
+package site.praytogether.pray_together.domain.memberroom.service;
+
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.DEFAULT_INFINITE_SCROLL_AFTER;
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.ROOMS_INFINITE_SCROLL_SIZE;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+import site.praytogether.pray_together.domain.memberroom.repository.MemberRoomRepository;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRoomService {
+  private final MemberRoomRepository memberRoomRepository;
+
+  public LinkedHashMap<Long, RoomInfo> fetchRoomsByMember(
+      Long memberId, RoomScrollRequest request) {
+    // Todo: request의 orderBy 및 dir에 따른 repository 메서드 차별과 필요 - 전략패턴 (time,name,memberCnt ...) ?
+
+    List<RoomInfo> roomInfos;
+    if (DEFAULT_INFINITE_SCROLL_AFTER.equals(request.getAfter())) {
+      roomInfos = fetchRoomsByFirst(memberId);
+    } else {
+      roomInfos = fetchRoomsByAfter(memberId, request);
+    }
+    return convertToLinkedMap(roomInfos);
+  }
+
+  private List<RoomInfo> fetchRoomsByAfter(Long memberId, RoomScrollRequest request) {
+    return memberRoomRepository.findRoomInfoOrderByJoinedTimeDesc(
+        memberId, Instant.parse(request.getAfter()), PageRequest.of(0, ROOMS_INFINITE_SCROLL_SIZE));
+  }
+
+  private List<RoomInfo> fetchRoomsByFirst(Long memberId) {
+    return memberRoomRepository.findFirstRoomInfoOrderByJoinedTimeDesc(
+        memberId, PageRequest.of(0, ROOMS_INFINITE_SCROLL_SIZE));
+  }
+
+  private LinkedHashMap<Long, RoomInfo> convertToLinkedMap(List<RoomInfo> roomInfos) {
+    return roomInfos.stream()
+        .collect(
+            Collectors.toMap(
+                RoomInfo::getRoomId,
+                info -> info,
+                (existing, replacement) -> existing,
+                LinkedHashMap::new));
+  }
+
+  public List<RoomIdMemberCnt> fetchRoomIdAndMemberCnt(List<Long> roomIds) {
+    return memberRoomRepository.findMemberCntByIds(roomIds);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/memberroom/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/memberroom/service/MemberRoomService.java
@@ -10,50 +10,66 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.memberroom.model.MemberRoom;
 import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
 import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
 import site.praytogether.pray_together.domain.memberroom.repository.MemberRoomRepository;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
+import site.praytogether.pray_together.domain.room.model.Room;
+import site.praytogether.pray_together.domain.room.model.RoomRole;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberRoomService {
   private final MemberRoomRepository memberRoomRepository;
 
+  @Transactional
+  public MemberRoom addMemberToRoom(Member member, Room room, RoomRole role) {
+    MemberRoom memberRoom =
+        MemberRoom.builder().member(member).room(room).role(role).isNotification(true).build();
+    return memberRoomRepository.save(memberRoom);
+  }
+
   public LinkedHashMap<Long, RoomInfo> fetchRoomsByMember(
-      Long memberId, RoomScrollRequest request) {
-    // Todo: request의 orderBy 및 dir에 따른 repository 메서드 차별과 필요 - 전략패턴 (time,name,memberCnt ...) ?
+      Long memberId, RoomScrollRequest scrollRequest) {
+    // TODO: 전략 패턴으로 orderBy 및 dir에 따른 repository 메서드 차별화 구현 (time, name, memberCnt 등)
 
     List<RoomInfo> roomInfos;
-    if (DEFAULT_INFINITE_SCROLL_AFTER.equals(request.getAfter())) {
-      roomInfos = fetchRoomsByFirst(memberId);
-    } else {
-      roomInfos = fetchRoomsByAfter(memberId, request);
+    if (DEFAULT_INFINITE_SCROLL_AFTER.equals(scrollRequest.getAfter())) {
+      roomInfos = fetchInitialRooms(memberId);
+      return convertToOrderedMap(roomInfos);
     }
-    return convertToLinkedMap(roomInfos);
+
+    roomInfos = fetchRoomsByAfter(memberId, scrollRequest);
+    return convertToOrderedMap(roomInfos);
   }
 
-  private List<RoomInfo> fetchRoomsByAfter(Long memberId, RoomScrollRequest request) {
+  public List<RoomIdMemberCnt> fetchRoomMemberCounts(List<Long> roomIds) {
+    return memberRoomRepository.findMemberCntByIds(roomIds);
+  }
+
+  private List<RoomInfo> fetchRoomsByAfter(Long memberId, RoomScrollRequest scrollRequest) {
     return memberRoomRepository.findRoomInfoOrderByJoinedTimeDesc(
-        memberId, Instant.parse(request.getAfter()), PageRequest.of(0, ROOMS_INFINITE_SCROLL_SIZE));
+        memberId,
+        Instant.parse(scrollRequest.getAfter()),
+        PageRequest.of(0, ROOMS_INFINITE_SCROLL_SIZE));
   }
 
-  private List<RoomInfo> fetchRoomsByFirst(Long memberId) {
+  private List<RoomInfo> fetchInitialRooms(Long memberId) {
     return memberRoomRepository.findFirstRoomInfoOrderByJoinedTimeDesc(
         memberId, PageRequest.of(0, ROOMS_INFINITE_SCROLL_SIZE));
   }
 
-  private LinkedHashMap<Long, RoomInfo> convertToLinkedMap(List<RoomInfo> roomInfos) {
+  private LinkedHashMap<Long, RoomInfo> convertToOrderedMap(List<RoomInfo> roomInfos) {
     return roomInfos.stream()
         .collect(
             Collectors.toMap(
                 RoomInfo::getRoomId,
-                info -> info,
+                roomInfo -> roomInfo,
                 (existing, replacement) -> existing,
                 LinkedHashMap::new));
-  }
-
-  public List<RoomIdMemberCnt> fetchRoomIdAndMemberCnt(List<Long> roomIds) {
-    return memberRoomRepository.findMemberCntByIds(roomIds);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/applicatoin/RoomApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/applicatoin/RoomApplicationService.java
@@ -8,12 +8,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.base.MessageResponse;
 import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member.model.MemberIdName;
 import site.praytogether.pray_together.domain.member.service.MemberService;
 import site.praytogether.pray_together.domain.member_room.exception.MemberRoomNotFoundException;
-import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount;
 import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
 import site.praytogether.pray_together.domain.member_room.service.MemberRoomService;
 import site.praytogether.pray_together.domain.room.dto.RoomCreateRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomMemberResponse;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
 import site.praytogether.pray_together.domain.room.model.Room;
@@ -45,7 +47,7 @@ public class RoomApplicationService {
         memberRoomService.fetchRoomsByMember(memberId, scrollRequest);
 
     List<Long> roomIds = roomInfoMap.keySet().stream().toList();
-    List<RoomIdMemberCnt> roomMemberCounts = memberRoomService.fetchRoomMemberCounts(roomIds);
+    List<RoomIdMemberCount> roomMemberCounts = memberRoomService.fetchRoomMemberCounts(roomIds);
 
     roomMemberCounts.forEach(
         roomMemberCount ->
@@ -64,5 +66,11 @@ public class RoomApplicationService {
       throw new MemberRoomNotFoundException(memberId, roomId);
     }
     return MessageResponse.of("방을 나갔습니다.");
+  }
+
+  public RoomMemberResponse listRoomParticipants(Long memberId, Long roomId) {
+    memberRoomService.validateMemberExistInRoom(memberId, roomId);
+    List<MemberIdName> memberIdNames = memberRoomService.fetchMembersInRoom(roomId);
+    return RoomMemberResponse.of(memberIdNames);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/applicatoin/RoomApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/applicatoin/RoomApplicationService.java
@@ -1,0 +1,64 @@
+package site.praytogether.pray_together.domain.room.applicatoin;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.praytogether.pray_together.domain.base.MessageResponse;
+import site.praytogether.pray_together.domain.member.expcetion.MemberNotFoundException;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member.service.MemberService;
+import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+import site.praytogether.pray_together.domain.memberroom.service.MemberRoomService;
+import site.praytogether.pray_together.domain.room.dto.RoomCreateRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
+import site.praytogether.pray_together.domain.room.model.Room;
+import site.praytogether.pray_together.domain.room.model.RoomRole;
+import site.praytogether.pray_together.domain.room.service.RoomService;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomApplicationService {
+
+  private final RoomService roomService;
+  private final MemberService memberService;
+  private final MemberRoomService memberRoomService;
+
+  @Transactional
+  public MessageResponse createRoom(Long memberId, RoomCreateRequest createRequest) {
+    Room createdRoom =
+        roomService.createRoom(createRequest.getName(), createRequest.getDescription());
+    Member memberRef = findMemberRefOrThrow(memberId);
+    memberRoomService.addMemberToRoom(memberRef, createdRoom, RoomRole.OWNER);
+    return MessageResponse.of("방 생성을 완료했습니다.");
+  }
+
+  public RoomScrollResponse fetchRoomsInfiniteScroll(
+      Long memberId, RoomScrollRequest scrollRequest) {
+    LinkedHashMap<Long, RoomInfo> roomInfoMap =
+        memberRoomService.fetchRoomsByMember(memberId, scrollRequest);
+
+    List<Long> roomIds = roomInfoMap.keySet().stream().toList();
+    List<RoomIdMemberCnt> roomMemberCounts = memberRoomService.fetchRoomMemberCounts(roomIds);
+
+    roomMemberCounts.forEach(
+        roomMemberCount ->
+            roomInfoMap
+                .get(roomMemberCount.getRoomId())
+                .setMemberCnt(roomMemberCount.getMemberCnt()));
+
+    return RoomScrollResponse.of(roomInfoMap);
+  }
+
+  private Member findMemberRefOrThrow(Long memberId) {
+    return memberService
+        .getRefIfExist(memberId)
+        .orElseThrow(() -> new MemberNotFoundException(memberId));
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
@@ -19,6 +19,7 @@ import site.praytogether.pray_together.domain.auth.annotation.PrincipalId;
 import site.praytogether.pray_together.domain.base.MessageResponse;
 import site.praytogether.pray_together.domain.room.applicatoin.RoomApplicationService;
 import site.praytogether.pray_together.domain.room.dto.RoomCreateRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomMemberResponse;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
 
@@ -53,5 +54,12 @@ public class RoomController {
   public ResponseEntity<MessageResponse> deleteRoom(
       @PrincipalId Long memberId, @PathVariable Long roomId) {
     return ResponseEntity.status(HttpStatus.OK).body(roomApplication.deleteRoom(memberId, roomId));
+  }
+
+  @GetMapping("/:roomId/members")
+  public ResponseEntity<RoomMemberResponse> getRoomParticipants(
+      @PrincipalId Long memberId, @PathVariable Long roomId) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(roomApplication.listRoomParticipants(memberId, roomId));
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
@@ -1,0 +1,38 @@
+package site.praytogether.pray_together.domain.room.controller;
+
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.DEFAULT_INFINITE_SCROLL_AFTER;
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.DEFAULT_INFINITE_SCROLL_DIR;
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.DEFAULT_INFINITE_SCROLL_ORDER_BY;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.praytogether.pray_together.domain.auth.annotation.PrayTogetherMemberId;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
+import site.praytogether.pray_together.domain.room.service.RoomService;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/rooms")
+public class RoomController {
+
+  private final RoomService roomService;
+
+  @GetMapping
+  public ResponseEntity<RoomScrollResponse> getRoomsByScroll(
+      @PrayTogetherMemberId Long memberId,
+      @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_ORDER_BY) String orderBy,
+      @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_AFTER) String after,
+      @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_DIR) String dir) {
+    RoomScrollRequest request = RoomScrollRequest.of(orderBy, after, dir);
+    RoomScrollResponse roomScrollResponse = roomService.fetchRoomsInfiniteScroll(memberId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(roomScrollResponse);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import site.praytogether.pray_together.domain.auth.annotation.PrayTogetherMemberId;
+import site.praytogether.pray_together.domain.auth.annotation.PrincipalId;
 import site.praytogether.pray_together.domain.base.MessageResponse;
 import site.praytogether.pray_together.domain.room.applicatoin.RoomApplicationService;
 import site.praytogether.pray_together.domain.room.dto.RoomCreateRequest;
@@ -32,7 +32,7 @@ public class RoomController {
 
   @GetMapping
   public ResponseEntity<RoomScrollResponse> getRoomsByScroll(
-      @PrayTogetherMemberId Long memberId,
+      @PrincipalId Long memberId,
       @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_ORDER_BY) String orderBy,
       @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_AFTER) String after,
       @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_DIR) String dir) {
@@ -44,14 +44,14 @@ public class RoomController {
 
   @PostMapping
   public ResponseEntity<MessageResponse> createRoom(
-      @PrayTogetherMemberId Long memberId, RoomCreateRequest request) {
+      @PrincipalId Long memberId, RoomCreateRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(roomApplication.createRoom(memberId, request));
   }
 
   @DeleteMapping("/:roomId")
   public ResponseEntity<MessageResponse> deleteRoom(
-      @PrayTogetherMemberId Long memberId, @PathVariable Long roomId) {
+      @PrincipalId Long memberId, @PathVariable Long roomId) {
     return ResponseEntity.status(HttpStatus.OK).body(roomApplication.deleteRoom(memberId, roomId));
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,5 +47,11 @@ public class RoomController {
       @PrayTogetherMemberId Long memberId, RoomCreateRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(roomApplication.createRoom(memberId, request));
+  }
+
+  @DeleteMapping("/:roomId")
+  public ResponseEntity<MessageResponse> deleteRoom(
+      @PrayTogetherMemberId Long memberId, @PathVariable Long roomId) {
+    return ResponseEntity.status(HttpStatus.OK).body(roomApplication.deleteRoom(memberId, roomId));
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/controller/RoomController.java
@@ -9,13 +9,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.praytogether.pray_together.domain.auth.annotation.PrayTogetherMemberId;
+import site.praytogether.pray_together.domain.base.MessageResponse;
+import site.praytogether.pray_together.domain.room.applicatoin.RoomApplicationService;
+import site.praytogether.pray_together.domain.room.dto.RoomCreateRequest;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
 import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
-import site.praytogether.pray_together.domain.room.service.RoomService;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,7 +26,7 @@ import site.praytogether.pray_together.domain.room.service.RoomService;
 @RequestMapping("/api/v1/rooms")
 public class RoomController {
 
-  private final RoomService roomService;
+  private final RoomApplicationService roomApplication;
 
   @GetMapping
   public ResponseEntity<RoomScrollResponse> getRoomsByScroll(
@@ -32,7 +35,15 @@ public class RoomController {
       @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_AFTER) String after,
       @RequestParam(defaultValue = DEFAULT_INFINITE_SCROLL_DIR) String dir) {
     RoomScrollRequest request = RoomScrollRequest.of(orderBy, after, dir);
-    RoomScrollResponse roomScrollResponse = roomService.fetchRoomsInfiniteScroll(memberId, request);
+    RoomScrollResponse roomScrollResponse =
+        roomApplication.fetchRoomsInfiniteScroll(memberId, request);
     return ResponseEntity.status(HttpStatus.OK).body(roomScrollResponse);
+  }
+
+  @PostMapping
+  public ResponseEntity<MessageResponse> createRoom(
+      @PrayTogetherMemberId Long memberId, RoomCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(roomApplication.createRoom(memberId, request));
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomCreateRequest.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomCreateRequest.java
@@ -1,0 +1,12 @@
+package site.praytogether.pray_together.domain.room.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomCreateRequest {
+  private final String name;
+  private final String description;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomMemberResponse.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomMemberResponse.java
@@ -1,0 +1,16 @@
+package site.praytogether.pray_together.domain.room.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import site.praytogether.pray_together.domain.member.model.MemberIdName;
+
+@Getter
+@AllArgsConstructor
+public class RoomMemberResponse {
+  private final List<MemberIdName> members;
+
+  public static RoomMemberResponse of(List<MemberIdName> memberIdNames) {
+    return new RoomMemberResponse(memberIdNames);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollRequest.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollRequest.java
@@ -1,0 +1,19 @@
+package site.praytogether.pray_together.domain.room.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class RoomScrollRequest {
+  String orderBy;
+  String after;
+  String dir;
+
+  public static RoomScrollRequest of(String orderBy, String after, String dir) {
+    return new RoomScrollRequest(orderBy, after, dir);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollResponse.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollResponse.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/dto/RoomScrollResponse.java
@@ -1,0 +1,28 @@
+package site.praytogether.pray_together.domain.room.dto;
+
+import static site.praytogether.pray_together.constant.CoreConstant.MemberRoomConstant.ROOMS_INFINITE_SCROLL_SIZE;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomScrollResponse {
+  private final List<RoomInfo> rooms;
+
+  public static RoomScrollResponse of(LinkedHashMap<Long, RoomInfo> roomInfos) {
+    RoomScrollResponse response =
+        new RoomScrollResponse(new ArrayList<>(ROOMS_INFINITE_SCROLL_SIZE));
+    roomInfos.forEach((key, value) -> response.add(value));
+    return response;
+  }
+
+  private void add(RoomInfo info) {
+    rooms.add(info);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/model/Room.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/model/Room.java
@@ -1,0 +1,39 @@
+package site.praytogether.pray_together.domain.room.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.praytogether.pray_together.constant.CoreConstant.RoomConstant;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@Table(name = "room")
+@SequenceGenerator(
+    name = "ROOM_SEQ_GENERATOR",
+    sequenceName = "ROOM_SEQ",
+    initialValue = 1,
+    allocationSize = 50)
+public class Room extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ROOM_SEQ_GENERATOR")
+  private Long id;
+
+  @Column(nullable = false, length = RoomConstant.NAME_MAX_LEN)
+  private String name;
+
+  @Column(nullable = false, length = RoomConstant.DESCRIPTION_MAX_LEN)
+  private String description;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/model/Room.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/model/Room.java
@@ -36,4 +36,8 @@ public class Room extends BaseEntity {
 
   @Column(nullable = false, length = RoomConstant.DESCRIPTION_MAX_LEN)
   private String description;
+
+  public static Room create(String name, String description) {
+    return Room.builder().name(name).description(description).build();
+  }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/room/model/RoomRole.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/model/RoomRole.java
@@ -1,0 +1,5 @@
+package site.praytogether.pray_together.domain.room.model;
+
+public enum RoomRole {
+    OWNER,MEMBER
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/repository/RoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/repository/RoomRepository.java
@@ -1,0 +1,6 @@
+package site.praytogether.pray_together.domain.room.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.praytogether.pray_together.domain.room.model.Room;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {}

--- a/src/main/java/site/praytogether/pray_together/domain/room/service/RoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/service/RoomService.java
@@ -1,0 +1,34 @@
+package site.praytogether.pray_together.domain.room.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
+import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
+import site.praytogether.pray_together.domain.memberroom.service.MemberRoomService;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
+import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
+import site.praytogether.pray_together.domain.room.repository.RoomRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RoomService {
+
+  private final RoomRepository roomRepository;
+  private final MemberRoomService memberRoomService;
+
+  public RoomScrollResponse fetchRoomsInfiniteScroll(Long memberId, RoomScrollRequest request) {
+    LinkedHashMap<Long, RoomInfo> roomInfos =
+        memberRoomService.fetchRoomsByMember(memberId, request);
+
+    List<Long> roomIds = roomInfos.keySet().stream().toList();
+    List<RoomIdMemberCnt> roomIdMembers = memberRoomService.fetchRoomIdAndMemberCnt(roomIds);
+    roomIdMembers.forEach(
+        idMember -> roomInfos.get(idMember.getRoomId()).setMemberCnt(idMember.getMemberCnt()));
+
+    return RoomScrollResponse.of(roomInfos);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/room/service/RoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/room/service/RoomService.java
@@ -1,34 +1,23 @@
 package site.praytogether.pray_together.domain.room.service;
 
-import java.util.LinkedHashMap;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import site.praytogether.pray_together.domain.memberroom.model.RoomIdMemberCnt;
-import site.praytogether.pray_together.domain.memberroom.model.RoomInfo;
-import site.praytogether.pray_together.domain.memberroom.service.MemberRoomService;
-import site.praytogether.pray_together.domain.room.dto.RoomScrollRequest;
-import site.praytogether.pray_together.domain.room.dto.RoomScrollResponse;
+import org.springframework.transaction.annotation.Transactional;
+import site.praytogether.pray_together.domain.room.model.Room;
 import site.praytogether.pray_together.domain.room.repository.RoomRepository;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoomService {
 
   private final RoomRepository roomRepository;
-  private final MemberRoomService memberRoomService;
 
-  public RoomScrollResponse fetchRoomsInfiniteScroll(Long memberId, RoomScrollRequest request) {
-    LinkedHashMap<Long, RoomInfo> roomInfos =
-        memberRoomService.fetchRoomsByMember(memberId, request);
-
-    List<Long> roomIds = roomInfos.keySet().stream().toList();
-    List<RoomIdMemberCnt> roomIdMembers = memberRoomService.fetchRoomIdAndMemberCnt(roomIds);
-    roomIdMembers.forEach(
-        idMember -> roomInfos.get(idMember.getRoomId()).setMemberCnt(idMember.getMemberCnt()));
-
-    return RoomScrollResponse.of(roomInfos);
+  @Transactional
+  public Room createRoom(String name, String description) {
+    Room newRoom = Room.create(name, description);
+    return roomRepository.save(newRoom);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/exception/BaseException.java
+++ b/src/main/java/site/praytogether/pray_together/exception/BaseException.java
@@ -1,9 +1,9 @@
-package site.praytogether.pray_together.common.exception;
+package site.praytogether.pray_together.exception;
 
 import java.util.StringJoiner;
 import lombok.AccessLevel;
 import lombok.Getter;
-import site.praytogether.pray_together.common.exception.spec.ExceptionSpec;
+import site.praytogether.pray_together.exception.spec.ExceptionSpec;
 
 @Getter
 public abstract class BaseException extends RuntimeException{

--- a/src/main/java/site/praytogether/pray_together/exception/ExceptionField.java
+++ b/src/main/java/site/praytogether/pray_together/exception/ExceptionField.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.common.exception;
+package site.praytogether.pray_together.exception;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/site/praytogether/pray_together/exception/ExceptionField.java
+++ b/src/main/java/site/praytogether/pray_together/exception/ExceptionField.java
@@ -4,33 +4,34 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ExceptionField {
-    private final Map<String,Object> fields;
+  private final Map<String, Object> fields;
 
-    private ExceptionField(Map<String,Object> fields){
-        this.fields = fields;
+  private ExceptionField(Map<String, Object> fields) {
+    this.fields = fields;
+  }
+
+  public Map<String, Object> get() {
+    return fields;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final Map<String, Object> fields;
+
+    private Builder() {
+      this.fields = new HashMap<>();
     }
 
-    public Map<String,Object> get() {
-        return fields;
+    public Builder add(String key, Object value) {
+      this.fields.put(key, value);
+      return this;
     }
 
-    public static Builder builder(){
-        return new Builder();
+    public ExceptionField build() {
+      return new ExceptionField(fields);
     }
-
-    private static class Builder{
-        private final Map<String,Object> fields;
-        private Builder(){
-            this.fields = new HashMap<>();
-        }
-
-        public Builder add(String key, Object value){
-            this.fields.put(key, value);
-            return this;
-        }
-
-        public ExceptionField build(){
-            return new ExceptionField(fields);
-        }
-    }
+  }
 }

--- a/src/main/java/site/praytogether/pray_together/exception/ExceptionResponse.java
+++ b/src/main/java/site/praytogether/pray_together/exception/ExceptionResponse.java
@@ -1,9 +1,8 @@
-package site.praytogether.pray_together.common.exception;
+package site.praytogether.pray_together.exception;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/site/praytogether/pray_together/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/praytogether/pray_together/exception/GlobalExceptionHandler.java
@@ -1,11 +1,11 @@
-package site.praytogether.pray_together.common.exception;
+package site.praytogether.pray_together.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import site.praytogether.pray_together.common.exception.spec.ExceptionSpec;
+import site.praytogether.pray_together.exception.spec.ExceptionSpec;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/site/praytogether/pray_together/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/praytogether/pray_together/exception/GlobalExceptionHandler.java
@@ -11,12 +11,14 @@ import site.praytogether.pray_together.exception.spec.ExceptionSpec;
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    // API BaseException
-    @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ExceptionResponse> handleBaseException(BaseException e) {
-        log.error(e.getLogMessage());
-        ExceptionSpec exceptionSpec = e.getExceptionSpec();
-        return ResponseEntity.status(exceptionSpec.getStatue())
-                .body(ExceptionResponse.of(exceptionSpec.getStatue().value(),exceptionSpec.getCode(),e.getClientMessage()));
-    }
+  // API BaseException
+  @ExceptionHandler(BaseException.class)
+  public ResponseEntity<ExceptionResponse> handleBaseException(BaseException e) {
+    log.error(e.getLogMessage());
+    ExceptionSpec exceptionSpec = e.getExceptionSpec();
+    return ResponseEntity.status(exceptionSpec.getStatus())
+        .body(
+            ExceptionResponse.of(
+                exceptionSpec.getStatus().value(), exceptionSpec.getCode(), e.getClientMessage()));
+  }
 }

--- a/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
@@ -1,4 +1,4 @@
-package site.praytogether.pray_together.common.exception.spec;
+package site.praytogether.pray_together.exception.spec;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
@@ -3,9 +3,11 @@ package site.praytogether.pray_together.exception.spec;
 import org.springframework.http.HttpStatus;
 
 public interface ExceptionSpec {
-    HttpStatus getStatue();
-    String getCode();
-    String getMessage(); // server log message
-    String name();
+  HttpStatus getStatus();
 
+  String getCode();
+
+  String getMessage(); // server log message
+
+  String name();
 }

--- a/src/main/java/site/praytogether/pray_together/exception/spec/MemberExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/MemberExceptionSpec.java
@@ -1,0 +1,16 @@
+package site.praytogether.pray_together.exception.spec;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberExceptionSpec implements ExceptionSpec {
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "회원 정보를 찾을 수 없습니다."),
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/site/praytogether/pray_together/exception/spec/MemberRoomExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/MemberRoomExceptionSpec.java
@@ -1,0 +1,15 @@
+package site.praytogether.pray_together.exception.spec;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRoomExceptionSpec implements ExceptionSpec {
+  MEMBER_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_ROOM-001", "회원이 속한 방을 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

close #7

## 변경사항

- 기존의 `common` or `domain` 패키지 구조에서 `config`, `constant`, `domain`, `exception` 등 모두 한 곳에 모아 관리하도록 변경합니다.
- 개발용 Oracle RDBMS 설정을 추가했습니다.
- Room 도메인 관련 API를 작성했습니다.
  - 방 생성
  - 방 나가기(삭제)
  - 방 참가자 명단 조회
  - 방 목록 무한 스크롤

- Room API 작성을 위해 `Member`, 인증 객체(`PrayerTotegherPrincipal`), Controller에서 memberId 자동 추출을 위한 `@PrincipalId`를 추가했습니다.
- JPA Entity의 `BaseEntity`를 설정합니다.
- JpaAudit을 설정하여 Entity 생성/업데이트 시, ID와 Time을 자동으로 기록합니다.
- Application Service 계층 추가
  - `RoomApplicationService` 안에 `RoomService` , `MemberService`, `MemberRoomService` 가 있으며, ApplicationService 계층에서 `Service`  코드를 조율하여 관리합니다.

- 