### PR TITLE
Feature/19 prayer notification api

### DIFF
--- a/src/main/java/site/praytogether/pray_together/domain/invitation/application/InvitationApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/application/InvitationApplicationService.java
@@ -54,7 +54,7 @@ public class InvitationApplicationService {
   @Transactional
   public MessageResponse inviteMemberToRoom(Long inviterMemberId, InvitationCreateRequest request) {
     memberRoomService.validateMemberExistInRoom(inviterMemberId, request.getRoomId());
-    Member inviter = memberService.getById(inviterMemberId);
+    Member inviter = memberService.fetchById(inviterMemberId);
     Member invitee = memberService.getByEmail(request.getEmail());
     Room roomRef = roomService.getRefOrThrow(request.getRoomId());
     invitationService.create(inviter, invitee, roomRef);

--- a/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
@@ -39,7 +39,7 @@ public class MemberService {
         .orElseThrow(() -> new MemberNotFoundException(email));
   }
 
-  public Member getById(Long id) {
+  public Member fetchById(Long id) {
     return memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id));
   }
 

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
@@ -32,6 +32,15 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
   @Query(
       """
+    SELECT mr.member.id
+    FROM MemberRoom mr
+    WHERE mr.room.id = :roomId
+
+""")
+  List<Long> findMember_IdByRoom_Id(Long roomId);
+
+  @Query(
+      """
       SELECT new site.praytogether.pray_together.domain.member_room.model.RoomInfo(
         r.id ,r.name, r.description,mr.createdTime ,mr.isNotification
       )

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -84,6 +84,10 @@ public class MemberRoomService {
     return memberRoomRepository.findMember_IdAndNameByRoom_Id(roomId);
   }
 
+  public List<Long> fetchMemberIdsInRoom(Long roomId) {
+    return memberRoomRepository.findMember_IdByRoom_Id(roomId);
+  }
+
   public void validateMemberExistInRoom(Long memberId, Long roomId) {
     if (memberRoomRepository.existsByMember_IdAndRoom_Id(memberId, roomId) == false) {
       throw new MemberRoomNotFoundException(memberId, roomId);

--- a/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationMessageFormat.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationMessageFormat.java
@@ -1,0 +1,5 @@
+package site.praytogether.pray_together.domain.notification.constant;
+
+public class NotificationMessageFormat {
+  public static final String PrayerCompletion = "%s님이 %s 기도제목으로 기도했습니다.\n기도로 함께 동참해 주세요!";
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationType.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationType.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum NotificationType {
-  PRAYER_COMPLETION,
-  ;
+public class NotificationType {
+  public static final String PRAYER_COMPLETION = "PRAYER_COMPLETION";
 }

--- a/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationType.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/constant/NotificationType.java
@@ -1,0 +1,11 @@
+package site.praytogether.pray_together.domain.notification.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+  PRAYER_COMPLETION,
+  ;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/event/EventPublisher.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/event/EventPublisher.java
@@ -1,8 +1,5 @@
 package site.praytogether.pray_together.domain.notification.event;
 
-import org.springframework.stereotype.Component;
-
-@Component
 public interface EventPublisher {
   public void publishPrayerComplete();
 }

--- a/src/main/java/site/praytogether/pray_together/domain/notification/event/EventPublisher.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/event/EventPublisher.java
@@ -1,0 +1,8 @@
+package site.praytogether.pray_together.domain.notification.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface EventPublisher {
+  public void publishPrayerComplete();
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/event/NotificationEventPublisher.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/event/NotificationEventPublisher.java
@@ -1,0 +1,10 @@
+package site.praytogether.pray_together.domain.notification.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationEventPublisher implements EventPublisher {
+
+  @Override
+  public void publishPrayerComplete() {}
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
@@ -1,0 +1,35 @@
+package site.praytogether.pray_together.domain.notification.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+
+@Entity
+@Getter
+@Table(name = "notification")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(
+    name = "notification_type",
+    discriminatorType = DiscriminatorType.STRING,
+    length = 50)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Notification extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "notification_seq_generator")
+  @SequenceGenerator(
+      name = "notification_seq_generator",
+      sequenceName = "notification_seq",
+      allocationSize = 50)
+  private Long id;
+
+  @Column(name = "sender_id", nullable = false)
+  private Long senderId;
+
+  @Column(name = "message", nullable = false, length = 500)
+  private String message;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
@@ -30,6 +30,9 @@ public class Notification extends BaseEntity {
   @Column(name = "sender_id", nullable = false)
   private Long senderId;
 
+  @Column(name = "recipient_id", nullable = false)
+  private Long recipientId;
+
   @Column(name = "message", nullable = false, length = 500)
   private String message;
 }

--- a/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/model/Notification.java
@@ -16,7 +16,7 @@ import site.praytogether.pray_together.domain.base.BaseEntity;
     discriminatorType = DiscriminatorType.STRING,
     length = 50)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
   @Id

--- a/src/main/java/site/praytogether/pray_together/domain/notification/model/PrayerCompletionNotification.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/model/PrayerCompletionNotification.java
@@ -1,0 +1,21 @@
+package site.praytogether.pray_together.domain.notification.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "prayer_completion_notification")
+@DiscriminatorValue("PRAYER_COMPLETION")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PrayerCompletionNotification extends Notification {
+
+  @Column(name = "prayer_title_id", nullable = false)
+  private Long prayerTitleId;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/model/PrayerCompletionNotification.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/model/PrayerCompletionNotification.java
@@ -1,5 +1,7 @@
 package site.praytogether.pray_together.domain.notification.model;
 
+import static site.praytogether.pray_together.domain.notification.constant.NotificationType.PRAYER_COMPLETION;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,13 +11,19 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "prayer_completion_notification")
-@DiscriminatorValue("PRAYER_COMPLETION")
-@Builder
+@Table(name = "PRAYER_COMPLETION_NOTIFICATION")
+@DiscriminatorValue(PRAYER_COMPLETION)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PrayerCompletionNotification extends Notification {
 
   @Column(name = "prayer_title_id", nullable = false)
   private Long prayerTitleId;
+
+  @Builder
+  public PrayerCompletionNotification(
+      Long senderId, Long recipientId, String message, Long prayerTitleId) {
+    super(null, senderId, recipientId, message);
+    this.prayerTitleId = prayerTitleId;
+  }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/notification/repository/PrayerCompletionNotificationRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/repository/PrayerCompletionNotificationRepository.java
@@ -1,0 +1,7 @@
+package site.praytogether.pray_together.domain.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.praytogether.pray_together.domain.notification.model.PrayerCompletionNotification;
+
+public interface PrayerCompletionNotificationRepository
+    extends JpaRepository<PrayerCompletionNotification, Long> {}

--- a/src/main/java/site/praytogether/pray_together/domain/notification/service/PrayerCompletionNotificationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/service/PrayerCompletionNotificationService.java
@@ -23,7 +23,7 @@ public class PrayerCompletionNotificationService {
           if (Objects.equals(recipientId, senderId)) return;
           notifications.add(
               PrayerCompletionNotification.builder()
-                  .prayerTitleId(prayerTitle.getCreatedBy())
+                  .prayerTitleId(prayerTitle.getId())
                   .recipientId(recipientId)
                   .senderId(senderId)
                   .message(message)

--- a/src/main/java/site/praytogether/pray_together/domain/notification/service/PrayerCompletionNotificationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/notification/service/PrayerCompletionNotificationService.java
@@ -1,0 +1,34 @@
+package site.praytogether.pray_together.domain.notification.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.notification.model.PrayerCompletionNotification;
+import site.praytogether.pray_together.domain.notification.repository.PrayerCompletionNotificationRepository;
+import site.praytogether.pray_together.domain.prayer.model.PrayerTitle;
+
+@Service
+@RequiredArgsConstructor
+public class PrayerCompletionNotificationService {
+  private final PrayerCompletionNotificationRepository notificationRepository;
+
+  public void create(
+      Long senderId, List<Long> recipientIds, String message, PrayerTitle prayerTitle) {
+    List<PrayerCompletionNotification> notifications = new ArrayList<>();
+
+    recipientIds.forEach(
+        recipientId -> {
+          if (Objects.equals(recipientId, senderId)) return;
+          notifications.add(
+              PrayerCompletionNotification.builder()
+                  .prayerTitleId(prayerTitle.getCreatedBy())
+                  .recipientId(recipientId)
+                  .senderId(senderId)
+                  .message(message)
+                  .build());
+        });
+    notificationRepository.saveAll(notifications);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/application/PrayerApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/application/PrayerApplicationService.java
@@ -1,11 +1,18 @@
 package site.praytogether.pray_together.domain.prayer.application;
 
+import static site.praytogether.pray_together.domain.notification.constant.NotificationMessageFormat.PrayerCompletion;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.base.MessageResponse;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member.service.MemberService;
 import site.praytogether.pray_together.domain.member_room.service.MemberRoomService;
+import site.praytogether.pray_together.domain.notification.event.EventPublisher;
+import site.praytogether.pray_together.domain.notification.service.PrayerCompletionNotificationService;
+import site.praytogether.pray_together.domain.prayer.dto.PrayerCompletionCreateRequest;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerContentResponse;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerCreateRequest;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerTitleInfiniteScrollRequest;
@@ -14,6 +21,7 @@ import site.praytogether.pray_together.domain.prayer.dto.PrayerUpdateRequest;
 import site.praytogether.pray_together.domain.prayer.model.PrayerContentInfo;
 import site.praytogether.pray_together.domain.prayer.model.PrayerTitle;
 import site.praytogether.pray_together.domain.prayer.model.PrayerTitleInfo;
+import site.praytogether.pray_together.domain.prayer.service.PrayerCompletionService;
 import site.praytogether.pray_together.domain.prayer.service.PrayerContentService;
 import site.praytogether.pray_together.domain.prayer.service.PrayerTitleService;
 import site.praytogether.pray_together.domain.room.model.Room;
@@ -23,11 +31,15 @@ import site.praytogether.pray_together.domain.room.service.RoomService;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PrayerApplicationService {
-
+  // todo: 개별 service 마다의 @Transaction 삭제
   private final PrayerTitleService titleService;
   private final PrayerContentService contentService;
   private final RoomService roomService;
   private final MemberRoomService memberRoomService;
+  private final MemberService memberService;
+  private final PrayerCompletionService completionService;
+  private final PrayerCompletionNotificationService notificationService;
+  private final EventPublisher eventPublisher;
 
   public PrayerContentResponse fetchPrayerContent(Long memberId, Long titleId) {
     validateMemberExistInRoomByTitleId(memberId, titleId);
@@ -66,6 +78,22 @@ public class PrayerApplicationService {
     validateMemberExistInRoomByTitleId(memberId, titleId);
     titleService.delete(titleId);
     return MessageResponse.of("기도를 삭제했습니다.");
+  }
+
+  @Transactional
+  public MessageResponse completePrayer(
+      Long senderId, Long prayerTitleId, PrayerCompletionCreateRequest request) {
+    validateMemberExistInRoomByTitleId(senderId, prayerTitleId);
+    PrayerTitle prayerTitle = titleService.fetchById(prayerTitleId);
+    completionService.create(senderId, prayerTitle);
+
+    List<Long> memberIds = memberRoomService.fetchMemberIdsInRoom(request.getRoomId());
+    Member member = memberService.fetchById(senderId);
+    String message = String.format(PrayerCompletion, member.getName(), prayerTitle.getTitle());
+    notificationService.create(senderId, memberIds, message, prayerTitle);
+
+    eventPublisher.publishPrayerComplete();
+    return MessageResponse.of("기도 완료 알림을 전송했습니다.");
   }
 
   private void validateMemberExistInRoomByTitleId(Long memberId, Long titleId) {

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/controller/PrayerController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/controller/PrayerController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.praytogether.pray_together.domain.auth.annotation.PrincipalId;
 import site.praytogether.pray_together.domain.base.MessageResponse;
 import site.praytogether.pray_together.domain.prayer.application.PrayerApplicationService;
+import site.praytogether.pray_together.domain.prayer.dto.PrayerCompletionCreateRequest;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerContentResponse;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerCreateRequest;
 import site.praytogether.pray_together.domain.prayer.dto.PrayerTitleInfiniteScrollRequest;
@@ -74,6 +75,16 @@ public class PrayerController {
       @PrincipalId Long memberId,
       @Positive(message = "잘 못된 기도 제목을 선택하셨습니다.") @PathVariable Long prayerTitleId) {
     MessageResponse response = prayerApplication.deletePrayer(memberId, prayerTitleId);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @PostMapping("/{prayerTitleId}/completion")
+  public ResponseEntity<MessageResponse> completePrayer(
+      @PrincipalId Long memberId,
+      @NotNull(message = "잘 못된 기도제목 입니다.") @Positive(message = "잘 못된 기도제목 입니다.") @PathVariable
+          Long prayerTitleId,
+      @Valid @RequestBody PrayerCompletionCreateRequest request) {
+    MessageResponse response = prayerApplication.completePrayer(memberId, prayerTitleId, request);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/dto/PrayerCompletionCreateRequest.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/dto/PrayerCompletionCreateRequest.java
@@ -1,0 +1,14 @@
+package site.praytogether.pray_together.domain.prayer.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PrayerCompletionCreateRequest {
+  @NotNull(message = "잘 못된 기도제목 입니다.")
+  @Positive(message = "잘 못된 기도제목 입니다.")
+  private final Long roomId;
+}

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerCompletion.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerCompletion.java
@@ -1,0 +1,46 @@
+package site.praytogether.pray_together.domain.prayer.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+
+@Entity
+@Table(name = "PRAYER_COMPLETION")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PrayerCompletion extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "prayer_completion_seq_generator")
+  @SequenceGenerator(
+      name = "prayer_completion_seq_generator",
+      sequenceName = "prayer_completion_seq",
+      allocationSize = 50)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "prayer_title_id")
+  private PrayerTitle prayerTitle;
+
+  @Column(name = "prayer_id", updatable = false, nullable = false)
+  private Long prayerId;
+
+  public static PrayerCompletion create(Long prayerId, PrayerTitle prayerTitle) {
+    return PrayerCompletion.builder().prayerId(prayerId).prayerTitle(prayerTitle).build();
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerContent.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerContent.java
@@ -43,7 +43,7 @@ public class PrayerContent extends BaseEntity {
   @Column(nullable = false, length = 30)
   private String memberName;
 
-  @Column(nullable = false, columnDefinition = "text")
+  @Column(nullable = false, columnDefinition = "CLOB")
   private String content;
 
   public static PrayerContent create(PrayerTitle title, PrayerRequestContent reqContent) {

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/respository/PrayerCompletionRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/respository/PrayerCompletionRepository.java
@@ -1,0 +1,6 @@
+package site.praytogether.pray_together.domain.prayer.respository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.praytogether.pray_together.domain.prayer.model.PrayerCompletion;
+
+public interface PrayerCompletionRepository extends JpaRepository<PrayerCompletion, Long> {}

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/service/PrayerCompletionService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/service/PrayerCompletionService.java
@@ -1,0 +1,18 @@
+package site.praytogether.pray_together.domain.prayer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.praytogether.pray_together.domain.prayer.model.PrayerCompletion;
+import site.praytogether.pray_together.domain.prayer.model.PrayerTitle;
+import site.praytogether.pray_together.domain.prayer.respository.PrayerCompletionRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PrayerCompletionService {
+  private final PrayerCompletionRepository completionRepository;
+
+  public void create(Long prayerId, PrayerTitle prayerTitle) {
+    PrayerCompletion prayerCompletion = PrayerCompletion.create(prayerId, prayerTitle);
+    completionRepository.save(prayerCompletion);
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/exception/BaseException.java
+++ b/src/main/java/site/praytogether/pray_together/exception/BaseException.java
@@ -17,7 +17,9 @@ public abstract class BaseException extends RuntimeException {
     this.exceptionField = fields;
   }
 
-  public String getLogMessage() {
+  public String
+      getLogMessage() { // todo: Client 메시지는 Global exception 혹은 개별 커스텀 Exception에서 직접 생성하여 처리하기,
+                        // Log는 spec 처리하기
     StringJoiner joiner = new StringJoiner(", ", "[ ", " ]");
     exceptionField.get().forEach((key, value) -> joiner.add(key + "=" + value));
     return String.format(

--- a/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/ExceptionSpec.java
@@ -7,7 +7,7 @@ public interface ExceptionSpec {
 
   String getCode();
 
-  String getDebugMessage(); // server log message
+  String getDebugMessage();
 
   String name();
 }

--- a/src/test/java/site/praytogether/pray_together/domain/prayer/PrayerCompletionIntegrateTest.java
+++ b/src/test/java/site/praytogether/pray_together/domain/prayer/PrayerCompletionIntegrateTest.java
@@ -1,0 +1,147 @@
+package site.praytogether.pray_together.domain.prayer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+import site.praytogether.pray_together.domain.base.MessageResponse;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
+import site.praytogether.pray_together.domain.notification.constant.NotificationMessageFormat;
+import site.praytogether.pray_together.domain.notification.model.PrayerCompletionNotification;
+import site.praytogether.pray_together.domain.prayer.dto.PrayerCompletionCreateRequest;
+import site.praytogether.pray_together.domain.prayer.model.PrayerCompletion;
+import site.praytogether.pray_together.domain.prayer.model.PrayerTitle;
+import site.praytogether.pray_together.domain.room.model.Room;
+import site.praytogether.pray_together.test_config.IntegrateTest;
+
+@DisplayName("기도 완료 처리 통합 테스트")
+public class PrayerCompletionIntegrateTest extends IntegrateTest {
+
+  private Member member;
+  private HttpHeaders headers;
+  private Room room;
+  private PrayerTitle prayerTitle;
+  private final String COMPLETION_URL_FORMAT = "/{prayerTitleId}/completion";
+
+  // 추가 회원 생성
+  private final int ADDITIONAL_MEMBERS_COUNT = 3;
+  private Member[] additionalMembers;
+
+  @BeforeEach
+  void setup() {
+    // 회원 생성
+    member = testUtils.createUniqueMember();
+    memberRepository.save(member);
+
+    // 방 생성
+    room = testUtils.createUniqueRoom();
+    roomRepository.save(room);
+
+    // 회원-방 연관관계 생성
+    MemberRoom memberRoom = testUtils.createUniqueMemberRoom_With_Member_AND_Room(member, room);
+    memberRoomRepository.save(memberRoom);
+
+    // 기도 제목 생성
+    prayerTitle = testUtils.createUniquePrayerTitle_With_Room(room);
+    prayerTitleRepository.save(prayerTitle);
+
+    // 추가 회원 생성 및 방에 참여시키기
+    additionalMembers = new Member[ADDITIONAL_MEMBERS_COUNT];
+    for (int i = 0; i < ADDITIONAL_MEMBERS_COUNT; i++) {
+      additionalMembers[i] = testUtils.createUniqueMember();
+      memberRepository.save(additionalMembers[i]);
+
+      MemberRoom additionalMemberRoom =
+          testUtils.createUniqueMemberRoom_With_Member_AND_Room(additionalMembers[i], room);
+      memberRoomRepository.save(additionalMemberRoom);
+    }
+
+    // 인증 헤더 생성
+    headers = testUtils.create_Auth_HttpHeader_With_Member(member);
+  }
+
+  @AfterEach
+  void cleanup() {
+    cleanRepository();
+  }
+
+  @Test
+  @DisplayName("기도 완료 처리 시 200 OK 응답 및 알림 생성 확인")
+  void complete_prayer_then_create_notifications_and_return_200_ok() {
+
+    // given
+    String uri =
+        UriComponentsBuilder.fromUriString(PRAYERS_API_URL)
+            .path(COMPLETION_URL_FORMAT)
+            .buildAndExpand(prayerTitle.getId())
+            .toUriString();
+
+    PrayerCompletionCreateRequest request =
+        PrayerCompletionCreateRequest.builder().roomId(room.getId()).build();
+
+    HttpEntity<PrayerCompletionCreateRequest> requestEntity = new HttpEntity<>(request, headers);
+
+    // when
+    ResponseEntity<MessageResponse> responseEntity =
+        restTemplate.exchange(uri, HttpMethod.POST, requestEntity, MessageResponse.class);
+
+    // then
+    // 응답 검증
+    assertThat(responseEntity.getStatusCode())
+        .as("기도 완료 처리 API 응답 상태 코드가 200 OK이 아닙니다.")
+        .isEqualTo(HttpStatus.OK);
+
+    MessageResponse response = responseEntity.getBody();
+    assertThat(response).as("기도 완료 처리 API 응답 결과가 NULL 입니다.").isNotNull();
+
+    // 기도 완료 엔티티 생성 검증
+    List<PrayerCompletion> completions = prayerCompletionRepository.findAll();
+    assertThat(completions).as("기도 완료 정보가 저장되지 않았습니다.").isNotEmpty();
+
+    assertThat(completions.size()).as("기도 완료 정보 개수가 예상과 다릅니다.").isEqualTo(1);
+
+    PrayerCompletion completion = completions.get(0);
+    assertThat(completion.getPrayerId())
+        .as("기도 완료 정보의 기도자 ID가 예상과 다릅니다.")
+        .isEqualTo(member.getId());
+
+    assertThat(completion.getPrayerTitle().getId())
+        .as("기도 완료 정보의 기도 제목 ID가 예상과 다릅니다.")
+        .isEqualTo(prayerTitle.getId());
+
+    // 알림 생성 검증
+    List<PrayerCompletionNotification> notifications =
+        prayerCompletionNotificationRepository.findAll();
+    assertThat(notifications).as("기도 완료 알림이 생성되지 않았습니다.").isNotEmpty();
+
+    assertThat(notifications.size())
+        .as("생성된 알림 개수가 예상과 다릅니다. (알림은 자신을 제외한 다른 멤버들에게만 전송됨)")
+        .isEqualTo(ADDITIONAL_MEMBERS_COUNT);
+
+    for (PrayerCompletionNotification notification : notifications) {
+      assertThat(notification.getSenderId()).as("알림의 발신자 ID가 예상과 다릅니다.").isEqualTo(member.getId());
+
+      assertThat(notification.getPrayerTitleId())
+          .as("알림의 기도 제목 ID가 예상과 다릅니다.")
+          .isEqualTo(prayerTitle.getId());
+
+      assertThat(notification.getMessage()).as("알림의 메시지가 NULL입니다.").isNotNull();
+
+      // 알림 메시지 형식 검증
+      String expectedMessage =
+          String.format(
+              NotificationMessageFormat.PrayerCompletion, member.getName(), prayerTitle.getTitle());
+      assertThat(notification.getMessage()).as("알림 메시지가 예상 형식과 다릅니다.").isEqualTo(expectedMessage);
+    }
+  }
+}

--- a/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
+++ b/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
@@ -8,6 +8,8 @@ import org.springframework.test.context.ActiveProfiles;
 import site.praytogether.pray_together.domain.invitation.repository.InvitationRepository;
 import site.praytogether.pray_together.domain.member.repository.MemberRepository;
 import site.praytogether.pray_together.domain.member_room.repository.MemberRoomRepository;
+import site.praytogether.pray_together.domain.notification.repository.PrayerCompletionNotificationRepository;
+import site.praytogether.pray_together.domain.prayer.respository.PrayerCompletionRepository;
 import site.praytogether.pray_together.domain.prayer.respository.PrayerContentRepository;
 import site.praytogether.pray_together.domain.prayer.respository.PrayerTitleRepository;
 import site.praytogether.pray_together.domain.room.repository.RoomRepository;
@@ -23,6 +25,11 @@ public class IntegrateTest {
   @Autowired protected PrayerTitleRepository prayerTitleRepository;
   @Autowired protected PrayerContentRepository prayerContentRepository;
   @Autowired protected InvitationRepository invitationRepository;
+  @Autowired protected PrayerCompletionRepository prayerCompletionRepository;
+
+  @Autowired
+  protected PrayerCompletionNotificationRepository prayerCompletionNotificationRepository;
+
   @Autowired protected TestUtils testUtils;
 
   private final String API_VERSION = "/api/v1";
@@ -33,6 +40,8 @@ public class IntegrateTest {
 
   protected void cleanRepository() {
     // delete order is very important
+    prayerCompletionRepository.deleteAll();
+    prayerCompletionNotificationRepository.deleteAll();
     invitationRepository.deleteAll();
     prayerContentRepository.deleteAll();
     prayerTitleRepository.deleteAll();


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

close #19

## 변경사항
- 기도 완료 알림 API를 추가했습니다. (실제 FCM 알림은 추후 개발 예정)
- 기도 완료 알림 API URL을 변경 하였습니다. `/notifications` -> `/prayer/1/completion`
  - `알림 -> 기도완료` 의미를 가진 도메인이 아닌, `기도완료 -> 알림` 도메인으로서, `기도완료` 라는 행동이 있기에 부가적으로 `알림`이 발생한다는 의미로 수정하였습니다. 