### PR TITLE
Feature/23 connet app auth

### DIFF
--- a/src/main/java/site/praytogether/pray_together/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/controller/AuthController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +17,6 @@ import site.praytogether.pray_together.domain.auth.dto.AuthTokenReissueResponse;
 import site.praytogether.pray_together.domain.auth.dto.EmailOtpRequest;
 import site.praytogether.pray_together.domain.auth.dto.OtpVerifyRequest;
 import site.praytogether.pray_together.domain.auth.dto.SignupRequest;
-import site.praytogether.pray_together.domain.auth.model.PrayTogetherPrincipal;
 import site.praytogether.pray_together.domain.base.MessageResponse;
 
 @RestController
@@ -67,11 +65,10 @@ public class AuthController {
 
   @PostMapping("/reissue-token")
   public ResponseEntity<AuthTokenReissueResponse> reissueRefreshToken(
-      @AuthenticationPrincipal PrayTogetherPrincipal principal,
       @Valid @RequestBody AuthTokenReissueRequest request) {
-    log.info("[API] JWT 재발급 요청 시작 memberId={}", principal.getId());
-    AuthTokenReissueResponse response = authApplication.reissueAuthToken(principal, request);
-    log.info("[API] JWT 재발급 요청 종료 memberId={}", principal.getId());
+    log.info("[API] JWT 재발급 요청 시작");
+    AuthTokenReissueResponse response = authApplication.reissueAuthToken(request);
+    log.info("[API] JWT 재발급 요청 종료");
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/dto/SignupRequest.java
@@ -2,7 +2,6 @@ package site.praytogether.pray_together.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,6 +21,7 @@ public class SignupRequest {
 
   @NotBlank(message = "비밀번호를 입력해 주세요.")
   @Size(min = 6, max = 15, message = "비밀번호는 6자 이상 15자 이하로 입력해 주세요.")
-  @Pattern(regexp = "^.*[!@#$%^&*(),.?\":{}|<>].*$", message = "비밀번호는 최소 1개 이상의 특수 문자를 포함해야 합니다.")
+  //  @Pattern(regexp = "^.*[!@#$%^&*(),.?\":{}|<>].*$", message = "비밀번호는 최소 1개 이상의 특수 문자를 포함해야
+  // 합니다.")
   private final String password;
 }

--- a/src/main/java/site/praytogether/pray_together/domain/auth/exception/AuthExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/exception/AuthExceptionSpec.java
@@ -14,8 +14,8 @@ public enum AuthExceptionSpec implements ExceptionSpec {
   INCORRECT_EMAIL_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH-003", "이메일 또는 비밀번호가 올바르지 않습니다."),
   UNKNOWN_AUTHENTICATION_FAILURE(
       HttpStatus.BAD_REQUEST, "AUTH-004", "Auth Entry Point 에서 알 수 없는 이유로 인증에 실패했습니다."),
-  JWT_EXCEPTION(HttpStatus.BAD_REQUEST, "AUTH-005", "JWT 인증에 실패했습니다."),
-  JWT_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH-006", "JWT가 만료되었습니다."),
+  ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH-005", "JWT(accessToken) 인증에 실패했습니다."),
+  ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-006", "JWT(accessToken)가 만료되었습니다."),
   REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-007", "RefreshToken을 cache에서 찾을 수 없습니다."),
   REFRESH_TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "AUTH-008", "RefreshToken이 유효하지 않습니다."),
   OTP_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH-009", "email에 해당하는 OTP가 없습니다."),

--- a/src/main/java/site/praytogether/pray_together/domain/auth/exception/AuthExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/exception/AuthExceptionSpec.java
@@ -16,8 +16,8 @@ public enum AuthExceptionSpec implements ExceptionSpec {
       HttpStatus.BAD_REQUEST, "AUTH-004", "Auth Entry Point 에서 알 수 없는 이유로 인증에 실패했습니다."),
   ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH-005", "JWT(accessToken) 인증에 실패했습니다."),
   ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-006", "JWT(accessToken)가 만료되었습니다."),
-  REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-007", "RefreshToken을 cache에서 찾을 수 없습니다."),
-  REFRESH_TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "AUTH-008", "RefreshToken이 유효하지 않습니다."),
+  REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-007", "RefreshToken을 cache에서 찾을 수 없습니다."),
+  REFRESH_TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "AUTH-008", "RefreshToken이 유효하지 않습니다."),
   OTP_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH-009", "email에 해당하는 OTP가 없습니다."),
   ;
 

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomInfo.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/model/RoomInfo.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RoomInfo {
-  private Long roomId;
+  private Long id;
   private String name;
   private Long memberCnt;
   private String description;
@@ -19,7 +19,7 @@ public class RoomInfo {
 
   public RoomInfo(
       Long id, String name, String description, Instant createdTime, boolean isNotification) {
-    this.roomId = id;
+    this.id = id;
     this.name = name;
     this.memberCnt = 0L;
     this.description = description;

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -69,7 +69,7 @@ public class MemberRoomService {
     return roomInfos.stream()
         .collect(
             Collectors.toMap(
-                RoomInfo::getRoomId,
+                RoomInfo::getId,
                 roomInfo -> roomInfo,
                 (existing, replacement) -> existing,
                 LinkedHashMap::new));

--- a/src/main/java/site/praytogether/pray_together/security/handler/AuthenticationEntryPointImpl.java
+++ b/src/main/java/site/praytogether/pray_together/security/handler/AuthenticationEntryPointImpl.java
@@ -1,7 +1,7 @@
 package site.praytogether.pray_together.security.handler;
 
-import static site.praytogether.pray_together.domain.auth.exception.AuthExceptionSpec.JWT_EXCEPTION;
-import static site.praytogether.pray_together.domain.auth.exception.AuthExceptionSpec.JWT_EXPIRED;
+import static site.praytogether.pray_together.domain.auth.exception.AuthExceptionSpec.ACCESS_TOKEN_EXCEPTION;
+import static site.praytogether.pray_together.domain.auth.exception.AuthExceptionSpec.ACCESS_TOKEN_EXPIRED;
 import static site.praytogether.pray_together.domain.auth.exception.AuthExceptionSpec.UNKNOWN_AUTHENTICATION_FAILURE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,11 +61,11 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     String code;
 
     if (e instanceof ExpiredJwtException) {
-      status = JWT_EXPIRED.getStatus().value();
-      code = JWT_EXPIRED.getCode();
+      status = ACCESS_TOKEN_EXPIRED.getStatus().value();
+      code = ACCESS_TOKEN_EXPIRED.getCode();
     } else {
-      status = JWT_EXCEPTION.getStatus().value();
-      code = JWT_EXPIRED.getCode();
+      status = ACCESS_TOKEN_EXCEPTION.getStatus().value();
+      code = ACCESS_TOKEN_EXCEPTION.getCode();
     }
 
     ExceptionResponse errorResponse = ExceptionResponse.of(status, code, message);

--- a/src/main/java/site/praytogether/pray_together/security/handler/AuthenticationEntryPointImpl.java
+++ b/src/main/java/site/praytogether/pray_together/security/handler/AuthenticationEntryPointImpl.java
@@ -70,6 +70,7 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
 
     ExceptionResponse errorResponse = ExceptionResponse.of(status, code, message);
     response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    response.setStatus(status);
   }
 
   private String findJwtExceptionMessage(JwtException jwtException) {

--- a/src/test/java/site/praytogether/pray_together/domain/room/RoomInfiniteScrollIntegrateTest.java
+++ b/src/test/java/site/praytogether/pray_together/domain/room/RoomInfiniteScrollIntegrateTest.java
@@ -124,7 +124,7 @@ public class RoomInfiniteScrollIntegrateTest extends IntegrateTest {
         .isSortedAccordingTo(
             (room1, room2) -> room2.getJoinedTime().compareTo(room1.getJoinedTime()));
 
-    assertThat(rooms).as("모든 방의 ID가 홀수여야 합니다.").allMatch(room -> room.getRoomId() % 2 == 1);
+    assertThat(rooms).as("모든 방의 ID가 홀수여야 합니다.").allMatch(room -> room.getId() % 2 == 1);
   }
 
   private static Stream<Arguments> provideRoomInfiniteScrollParameters() {
@@ -183,7 +183,7 @@ public class RoomInfiniteScrollIntegrateTest extends IntegrateTest {
           .isSortedAccordingTo(
               (room1, room2) -> room2.getJoinedTime().compareTo(room1.getJoinedTime()));
 
-      assertThat(rooms).as("모든 방의 ID가 홀수여야 합니다.").allMatch(room -> room.getRoomId() % 2 == 1);
+      assertThat(rooms).as("모든 방의 ID가 홀수여야 합니다.").allMatch(room -> room.getId() % 2 == 1);
 
       // 다음 요청 준비
       RoomInfo lastRoom = rooms.get(rooms.size() - 1);


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

close #23

## 변경사항
- 토큰 관련 예외 응답 상태를 모두 `401 unauthorized` 로 변경
- 방 무한 스크롤 조회 API 응답 수정 ( API 명세서에 알맞게 응답 변경 )
- 토큰 재발급시 memberId를 요청으로 부터 가져오는 잘 못된 로직을 수정
- 회원가입 시, 비밀번호에 특수 문자 1개 이상을 포함하는 검증 로직을 제거 
  - UI에서 특수 문자에 대한 적절한 안내가 없기에, 사용자 경험과 기능을 일치 시키기 위해 당분간 특수 문자 검증 로직 제거