### PR TITLE
feat: 회원 탈퇴시 Fcm 토큰 DB Cascade 삭제 적용 #33

### DIFF
--- a/src/main/java/site/praytogether/pray_together/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
     authApplication.withdraw(memberId);
     log.info("[API] 회원 탈퇴 요청 종료 memberId={}", memberId);
     return ResponseEntity.status(HttpStatus.OK)
-        .body(MessageResponse.of("회워 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."));
+        .body(MessageResponse.of("회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."));
   }
 
   @PostMapping("/otp/email")

--- a/src/main/java/site/praytogether/pray_together/domain/fcm_token/model/FcmToken.java
+++ b/src/main/java/site/praytogether/pray_together/domain/fcm_token/model/FcmToken.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import site.praytogether.pray_together.domain.base.BaseEntity;
 import site.praytogether.pray_together.domain.fcm_token.dto.FcmTokenRegisterRequest;
 import site.praytogether.pray_together.domain.member.model.Member;
@@ -36,6 +38,7 @@ public class FcmToken extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Member member;
 
   @Column(name = "token", nullable = false, length = 512)


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

close #33 

## 변경사항
  - 회원 탈퇴 시 FCM 토큰이 자동으로 삭제되도록 CASCADE 설정 추가
  - 회원 탈퇴 응답 메시지 오타 수정 ("회워" → "회원")


  1. FcmToken 엔티티 수정
    - Member와의 연관관계에 @OnDelete(action = OnDeleteAction.CASCADE) 추가
    - 회원 탈퇴 시 관련 FCM 토큰이 자동으로 삭제됨
  2. AuthController 응답 메시지 수정
    - 탈퇴 완료 메시지 오타 수정
