### PR TITLE
Feature/37 friend support 추가 커밋 - 기도방 초대 API 다수 초대 가능하도록 변경

### DIFF
--- a/src/main/java/site/praytogether/pray_together/domain/invitation/application/InvitationApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/application/InvitationApplicationService.java
@@ -66,11 +66,11 @@ public class InvitationApplicationService {
   @Transactional
   public MessageResponse inviteMemberToRoom(Long inviterMemberId, InvitationCreateRequestV2 request) {
     memberRoomService.validateMemberExistInRoom(inviterMemberId, request.getRoomId());
+    memberRoomService.validateMembersNotExistInRoom(request.getFriendIds(), request.getRoomId());
     Member inviter = memberService.fetchById(inviterMemberId);
-    Member invitee = memberService.fetchById(request.getFriendId());
-    memberRoomService.validateMemberNotExistInRoom(invitee.getId(), request.getRoomId());
+    List<Member> invitees = memberService.fetchByIds(request.getFriendIds());
     Room roomRef = roomService.getRefOrThrow(request.getRoomId());
-    invitationService.create(inviter, invitee, roomRef);
+    invitationService.create(inviter, invitees, roomRef);
     return MessageResponse.of("초대를 완료했습니다.");
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/invitation/domain/repository/InvitationRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/domain/repository/InvitationRepository.java
@@ -4,9 +4,12 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import site.praytogether.pray_together.domain.invitation.domain.Invitation;
 import site.praytogether.pray_together.domain.invitation.domain.InvitationInfo;
 import site.praytogether.pray_together.domain.invitation.domain.InvitationStatus;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.room.model.Room;
 
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
@@ -24,4 +27,16 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
         ORDER BY i.createdTime ASC
 """)
   List<InvitationInfo> findInfosByMemberId(Long memberId, InvitationStatus status);
+
+  @Query(
+      """
+        SELECT invitation
+        FROM Invitation invitation
+        WHERE invitation.room.id = :roomId 
+        AND invitation.status = :status 
+        AND invitation.invitee.id IN :inviteeIds
+"""
+  )
+
+List<Invitation> findByRoomIdAndStatusAndInviteeIds(@Param("roomId") Long roomId,@Param("status")  InvitationStatus invitationStatus,@Param("inviteeIds") List<Long> inviteeIds);
 }

--- a/src/main/java/site/praytogether/pray_together/domain/invitation/domain/service/InvitationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/domain/service/InvitationService.java
@@ -1,6 +1,10 @@
 package site.praytogether.pray_together.domain.invitation.domain.service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,8 +40,18 @@ public class InvitationService {
 
   public List<Invitation> create(Member inviter, List<Member> invitees, Room room) {
 
+    List<Long> inviteeIds = invitees.stream().map(Member::getId).toList();
+    List<Invitation> pendingInvitations =
+        invitationRepository.findByRoomIdAndStatusAndInviteeIds(room.getId(),InvitationStatus.PENDING,inviteeIds);
+
+    Set<Long> pendingIds = pendingInvitations.stream()
+        .map(Invitation::getInvitee)
+        .map(Member::getId)
+        .collect(Collectors.toSet());
+
     List<Invitation> invitations = invitees.stream()
-        .map(i -> Invitation.create(inviter, i, room))
+        .filter(invitee -> !pendingIds.contains(invitee.getId())) // not contains
+        .map(invitee -> Invitation.create(inviter, invitee, room))
         .toList();
 
     return invitationRepository.saveAll(invitations);

--- a/src/main/java/site/praytogether/pray_together/domain/invitation/domain/service/InvitationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/domain/service/InvitationService.java
@@ -28,11 +28,19 @@ public class InvitationService {
         .orElseThrow(() -> new InvitationNotFoundException(inviteeId, invitationId));
   }
 
-  @Transactional
   public Invitation create(Member inviter, Member invitee, Room room) {
     Invitation invitation = Invitation.create(inviter, invitee, room);
 
     return invitationRepository.save(invitation);
+  }
+
+  public List<Invitation> create(Member inviter, List<Member> invitees, Room room) {
+
+    List<Invitation> invitations = invitees.stream()
+        .map(i -> Invitation.create(inviter, i, room))
+        .toList();
+
+    return invitationRepository.saveAll(invitations);
   }
 
   @Transactional

--- a/src/main/java/site/praytogether/pray_together/domain/invitation/presentation/v2/dto/InvitationCreateRequestV2.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/presentation/v2/dto/InvitationCreateRequestV2.java
@@ -2,6 +2,8 @@ package site.praytogether.pray_together.domain.invitation.presentation.v2.dto;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +18,6 @@ public class InvitationCreateRequestV2 {
   @Positive(message = "잘 못된 방을 선택하셨습니다.")
   private final Long roomId;
 
-  @Positive(message = "친구 선택이 잘 못 되었습니다.")
-  private final Long friendId;
+  @Size(min = 1,message = "친구를 선택해 주세요.")
+  private final List<@Positive(message = "친구 선택이 잘 못 되었습니다.") Long> friendIds;
 }

--- a/src/main/java/site/praytogether/pray_together/domain/invitation/presentation/v2/dto/InvitationCreateRequestV2.java
+++ b/src/main/java/site/praytogether/pray_together/domain/invitation/presentation/v2/dto/InvitationCreateRequestV2.java
@@ -10,8 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class InvitationCreateRequestV2 {
 
   @NotNull(message = "잘 못된 방을 선택하셨습니다.")

--- a/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package site.praytogether.pray_together.domain.member.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,10 @@ public class MemberService {
 
   public Member fetchById(Long id) {
     return memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id));
+  }
+
+  public List<Member> fetchByIds(List<Long> ids) {
+    return memberRepository.findAllById(ids);
   }
 
   public void validateMemberExists(Long memberId) {

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/exception/SomoneAlreadyExistException.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/exception/SomoneAlreadyExistException.java
@@ -1,0 +1,23 @@
+package site.praytogether.pray_together.domain.member_room.exception;
+
+import java.util.List;
+import site.praytogether.pray_together.exception.ExceptionField;
+import site.praytogether.pray_together.exception.spec.ExceptionSpec;
+import site.praytogether.pray_together.exception.spec.MemberRoomExceptionSpec;
+
+public class SomoneAlreadyExistException extends MemberRoomException {
+
+
+  public SomoneAlreadyExistException(List<Long> memberIds, Long roomId) {
+    this(ExceptionField.builder().add("roomId", roomId).add("memberIds",memberIds).build());
+  }
+
+  protected SomoneAlreadyExistException(ExceptionField fields) {
+    super(MemberRoomExceptionSpec.SOMONE_ALREADY_EXIST, fields);
+  }
+
+  @Override
+  public String getClientMessage() {
+    return "이미 방에 참가한 회원이 있습니다.";
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/repository/MemberRoomRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import site.praytogether.pray_together.domain.member.model.MemberIdName;
 import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
 import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount;
@@ -75,4 +76,15 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
 """)
   List<RoomIdMemberCount> findMemberCountByIds(List<Long> roomIds);
+
+
+  @Query(
+      """
+      SELECT CASE WHEN COUNT(DISTINCT mr.member.id) > 0 THEN true ELSE false END 
+      FROM MemberRoom mr
+      WHERE mr.member.id IN :memberIds
+      AND mr.room.id = :roomId
+"""
+  )
+  boolean isExistingMembersInRoom(@Param("memberIds") List<Long> memberIds,@Param("roomId") Long roomId);
 }

--- a/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/member_room/service/MemberRoomService.java
@@ -15,6 +15,7 @@ import site.praytogether.pray_together.domain.member.model.Member;
 import site.praytogether.pray_together.domain.member.model.MemberIdName;
 import site.praytogether.pray_together.domain.member_room.exception.MemberRoomAlreadyExistException;
 import site.praytogether.pray_together.domain.member_room.exception.MemberRoomNotFoundException;
+import site.praytogether.pray_together.domain.member_room.exception.SomoneAlreadyExistException;
 import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
 import site.praytogether.pray_together.domain.member_room.model.RoomIdMemberCount;
 import site.praytogether.pray_together.domain.member_room.model.RoomInfo;
@@ -98,6 +99,13 @@ public class MemberRoomService {
   public void validateMemberNotExistInRoom(Long memberId, Long roomId) {
     if (memberRoomRepository.existsByMember_IdAndRoom_Id(memberId, roomId) == true) {
       throw new MemberRoomAlreadyExistException(memberId, roomId);
+    }
+  }
+
+  public void validateMembersNotExistInRoom(List<Long> memberIds, Long roomId) {
+    boolean exist = memberRoomRepository.isExistingMembersInRoom(memberIds, roomId);
+    if (exist) {
+      throw new SomoneAlreadyExistException(memberIds, roomId);
     }
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerCompletion.java
+++ b/src/main/java/site/praytogether/pray_together/domain/prayer/model/PrayerCompletion.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import site.praytogether.pray_together.domain.base.BaseEntity;
 
 @Entity
@@ -33,8 +35,9 @@ public class PrayerCompletion extends BaseEntity {
       allocationSize = 50)
   private Long id;
 
+  @OnDelete(action = OnDeleteAction.SET_NULL)
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "prayer_title_id")
+  @JoinColumn(name = "prayer_title_id", nullable = true)
   private PrayerTitle prayerTitle;
 
   @Column(name = "prayer_id", updatable = false, nullable = false)

--- a/src/main/java/site/praytogether/pray_together/exception/spec/MemberRoomExceptionSpec.java
+++ b/src/main/java/site/praytogether/pray_together/exception/spec/MemberRoomExceptionSpec.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberRoomExceptionSpec implements ExceptionSpec {
   MEMBER_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_ROOM-001", "회원이 속한 방을 찾을 수 없습니다."),
-  MEMBER_ROOM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_ROOM-002", "이미 방에 존재하는 회원입니다.");
+  MEMBER_ROOM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_ROOM-002", "이미 방에 존재하는 회원입니다."),
+  SOMONE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_ROOM-003", "이미 방에 존재하는 회원이 있습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/test/java/site/praytogether/pray_together/domain/invitation/InvitationCreateIntegrateTestV2.java
+++ b/src/test/java/site/praytogether/pray_together/domain/invitation/InvitationCreateIntegrateTestV2.java
@@ -1,0 +1,168 @@
+package site.praytogether.pray_together.domain.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import site.praytogether.pray_together.domain.invitation.presentation.v2.dto.InvitationCreateRequestV2;
+import site.praytogether.pray_together.domain.invitation.domain.Invitation;
+import site.praytogether.pray_together.domain.invitation.domain.InvitationStatus;
+import site.praytogether.pray_together.domain.member.model.Member;
+import site.praytogether.pray_together.domain.member_room.model.MemberRoom;
+import site.praytogether.pray_together.domain.room.model.Room;
+import site.praytogether.pray_together.exception.spec.MemberRoomExceptionSpec;
+import site.praytogether.pray_together.test_config.IntegrateTest;
+
+@DisplayName("방 초대 V2 통합 테스트 - 여러 명 초대")
+public class InvitationCreateIntegrateTestV2 extends IntegrateTest {
+  private Member memberInviter;
+  private Member friend1;
+  private Member friend2;
+  private Member friend3;
+  private Room room;
+  private String token;
+  private String ROOM_INVITATION_URL = "/invitations";
+
+  @BeforeEach
+  void setup() throws Exception {
+    memberInviter = testUtils.createUniqueMember();
+    memberRepository.save(memberInviter);
+
+    friend1 = testUtils.createUniqueMember();
+    friend2 = testUtils.createUniqueMember();
+    friend3 = testUtils.createUniqueMember();
+    memberRepository.saveAll(List.of(friend1, friend2, friend3));
+
+    room = testUtils.createUniqueRoom();
+    roomRepository.save(room);
+
+    MemberRoom memberRoom =
+        testUtils.createUniqueMemberRoom_With_Member_AND_Room(memberInviter, room);
+    memberRoomRepository.save(memberRoom);
+
+    token = testUtils.createBearerToken(memberInviter);
+  }
+
+  @Test
+  @DisplayName("여러 친구를 방에 초대하면 201 Created 응답 및 모든 초대장 생성")
+  void invite_multiple_friends_to_room_then_return_201_and_create_all_invitations() throws Exception {
+    // given
+    List<Long> friends = List.of(friend1.getId(), friend2.getId(), friend3.getId());
+    InvitationCreateRequestV2 request = new InvitationCreateRequestV2(room.getId(),friends);
+
+    // when
+    mockMvc.perform(post(API_VERSION_2 + ROOM_INVITATION_URL)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated());
+
+    // then
+    List<Invitation> allInvitations = invitationRepository.findAll();
+    assertThat(allInvitations).as("저장된 초대장의 개수가 예상과 다릅니다.").hasSize(friends.size());
+
+    assertThat(allInvitations)
+        .as("모든 초대장의 초대자가 동일해야 합니다.")
+        .allMatch(invitation -> invitation.getInviterName().equals(memberInviter.getName()));
+
+    assertThat(allInvitations)
+        .as("초대받은 사용자들이 예상과 다릅니다.")
+        .extracting(invitation -> invitation.getInvitee().getId())
+        .containsExactlyInAnyOrder(friend1.getId(), friend2.getId(), friend3.getId());
+
+    assertThat(allInvitations)
+        .as("모든 초대장이 동일한 방에 대한 것이어야 합니다.")
+        .allMatch(invitation -> invitation.getRoom().getId().equals(room.getId()));
+
+    assertThat(allInvitations)
+        .as("모든 초대장의 상태가 PENDING이어야 합니다.")
+        .allMatch(invitation -> invitation.getStatus() == InvitationStatus.PENDING);
+
+    assertThat(allInvitations)
+        .as("모든 초대장의 응답 시간은 null이어야 합니다.")
+        .allMatch(invitation -> invitation.getResponseTime() == null);
+  }
+
+  @Test
+  @DisplayName("초대할 친구 중 한 명이라도 이미 방에 있으면 400 Bad Request 응답")
+  void invite_friends_when_one_already_in_room_then_return_400() throws Exception {
+    // given
+    MemberRoom friend1InRoom =
+        testUtils.createUniqueMemberRoom_With_Member_AND_Room(friend1, room);
+    memberRoomRepository.save(friend1InRoom);
+
+    InvitationCreateRequestV2 request = new InvitationCreateRequestV2(
+        room.getId(),
+        List.of(friend1.getId(), friend2.getId(), friend3.getId())
+    );
+
+    // when & then
+    mockMvc.perform(post(API_VERSION_2 + ROOM_INVITATION_URL)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(MemberRoomExceptionSpec.SOMONE_ALREADY_EXIST.getCode()));
+
+    List<Invitation> allInvitations = invitationRepository.findAll();
+    assertThat(allInvitations).as("초대장이 생성되지 않아야 합니다.").isEmpty();
+  }
+
+  @Test
+  @DisplayName("빈 친구 리스트로 초대 시도하면 400 Bad Request 응답")
+  void invite_with_empty_friend_list_then_return_400() throws Exception {
+    // given
+    InvitationCreateRequestV2 request = new InvitationCreateRequestV2(
+        room.getId(),
+        List.of()
+    );
+
+    // when & then
+    mockMvc.perform(post(API_VERSION_2 + ROOM_INVITATION_URL)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("음수 친구 ID로 초대 시도하면 400 Bad Request 응답")
+  void invite_with_negative_friend_id_then_return_400() throws Exception {
+    // given
+    InvitationCreateRequestV2 request = new InvitationCreateRequestV2(
+        room.getId(),
+        List.of(-1L, friend2.getId())
+    );
+
+    // when & then
+    mockMvc.perform(post(API_VERSION_2 + ROOM_INVITATION_URL)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("0 친구 ID로 초대 시도하면 400 Bad Request 응답")
+  void invite_with_zero_friend_id_then_return_400() throws Exception {
+    // given
+    InvitationCreateRequestV2 request = new InvitationCreateRequestV2(
+        room.getId(),
+        List.of(0L, friend2.getId())
+    );
+
+    // when & then
+    mockMvc.perform(post(API_VERSION_2 + ROOM_INVITATION_URL)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
+++ b/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
@@ -42,7 +42,8 @@ public class IntegrateTest {
 
   @Autowired protected TestUtils testUtils;
 
-  private final String API_VERSION_1 = "/api/v1";
+  protected final String API_VERSION_1 = "/api/v1";
+  protected String API_VERSION_2 = "/api/v2";
   protected final String ROOMS_API_URL = API_VERSION_1 + "/rooms";
   protected final String PRAYERS_API_URL = API_VERSION_1 + "/prayers";
   protected final String MEMBERS_API_URL = API_VERSION_1 + "/members";

--- a/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
+++ b/src/test/java/site/praytogether/pray_together/test_config/IntegrateTest.java
@@ -42,10 +42,10 @@ public class IntegrateTest {
 
   @Autowired protected TestUtils testUtils;
 
-  private final String API_VERSION = "/api/v1";
-  protected final String ROOMS_API_URL = API_VERSION + "/rooms";
-  protected final String PRAYERS_API_URL = API_VERSION + "/prayers";
-  protected final String MEMBERS_API_URL = API_VERSION + "/members";
-  protected final String INVITATIONS_API_URL = API_VERSION + "/invitations";
-  protected final String FRIEND_API_URL = API_VERSION + "/friends";
+  private final String API_VERSION_1 = "/api/v1";
+  protected final String ROOMS_API_URL = API_VERSION_1 + "/rooms";
+  protected final String PRAYERS_API_URL = API_VERSION_1 + "/prayers";
+  protected final String MEMBERS_API_URL = API_VERSION_1 + "/members";
+  protected final String INVITATIONS_API_URL = API_VERSION_1 + "/invitations";
+  protected final String FRIEND_API_URL = API_VERSION_1 + "/friends";
 }


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 기도방 다수 초대시 초대 인원 만큼 API 호출하는 것이 아닌, 배열을 사용하여 한 번에 초대하는 것으로 변경
- 이미 기도방 초대장(Pending)을 가진 사람에게는 초대 발송 안함. 중복 초대를 막기 위한 설정
- 기도 제목 삭제 API 오류 해결 (PrayerCompletion 에 Cascade SET_NULL 로 설정 , 기도 제목이 사라져도 기도 횟수를 측정하기 위해서)