### PR TITLE
feat: RefreshToken 저장소 변경

### DIFF
--- a/src/main/java/site/praytogether/pray_together/domain/auth/application/AuthApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/application/AuthApplicationService.java
@@ -65,8 +65,7 @@ public class AuthApplicationService {
         PrayTogetherPrincipal.builder().id(member.getId()).email(member.getEmail()).build();
     String access = jwtService.issueAccessToken(principal);
     String refresh = jwtService.issueRefreshToken(principal);
-    refreshTokenService.save(
-        memberId, refresh, jwtService.extractExpiration(refresh));
+    refreshTokenService.save(member, refresh, jwtService.extractExpiration(refresh));
 
     return AuthTokenReissueResponse.of(access, refresh);
   }

--- a/src/main/java/site/praytogether/pray_together/domain/auth/application/AuthApplicationService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/application/AuthApplicationService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.auth.dto.AuthTokenReissueRequest;
 import site.praytogether.pray_together.domain.auth.dto.AuthTokenReissueResponse;
 import site.praytogether.pray_together.domain.auth.dto.OtpVerifyRequest;
@@ -20,6 +21,7 @@ import site.praytogether.pray_together.security.service.JwtService;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class AuthApplicationService {
   private final MemberService memberService;
   private final OtpService otpService;
@@ -50,20 +52,21 @@ public class AuthApplicationService {
     try {
       String refreshToken = request.getRefreshToken();
       memberId = jwtService.extractMemberId(refreshToken);
-      refreshTokenService.validateRefreshTokenExist(String.valueOf(memberId), refreshToken);
+      refreshTokenService.validateRefreshTokenExist(memberId, refreshToken);
 
       jwtService.isValid(request.getRefreshToken());
     } catch (JwtException e) {
       throw new RefreshTokenNotValidException(memberId);
     }
 
-    refreshTokenService.delete(String.valueOf(memberId));
+    refreshTokenService.delete(memberId);
     Member member = memberService.fetchById(memberId);
     PrayTogetherPrincipal principal =
         PrayTogetherPrincipal.builder().id(member.getId()).email(member.getEmail()).build();
     String access = jwtService.issueAccessToken(principal);
     String refresh = jwtService.issueRefreshToken(principal);
-    refreshTokenService.save(String.valueOf(memberId), refresh);
+    refreshTokenService.save(
+        memberId, refresh, jwtService.extractExpiration(refresh));
 
     return AuthTokenReissueResponse.of(access, refresh);
   }

--- a/src/main/java/site/praytogether/pray_together/domain/auth/model/RefreshToken.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/model/RefreshToken.java
@@ -1,0 +1,54 @@
+package site.praytogether.pray_together.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import site.praytogether.pray_together.domain.base.BaseEntity;
+import site.praytogether.pray_together.domain.member.model.Member;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@Table(name = "refresh_token")
+public class RefreshToken extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false, updatable = false, unique = true)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Member member;
+
+  @Column(name = "token", nullable = false, length = 512)
+  private String token;
+
+  @Column(name = "expired_time", nullable = false, columnDefinition = "TIMESTAMP(3) WITH TIME ZONE")
+  private Instant expiredTime;
+
+  public static RefreshToken create(Member member, String token, Instant expiredTime) {
+    return RefreshToken.builder().member(member).token(token).expiredTime(expiredTime).build();
+  }
+
+  public void updateToken(String token, Instant expiredTime) {
+    this.token = token;
+    this.expiredTime = expiredTime;
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package site.praytogether.pray_together.domain.auth.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.praytogether.pray_together.domain.auth.model.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+  Optional<RefreshToken> findByMemberId(Long memberId);
+
+  void deleteByMemberId(Long memberId);
+
+  boolean existsByMemberId(Long memberId);
+}

--- a/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
@@ -8,22 +8,18 @@ import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.auth.exception.RefreshTokenNotFoundException;
 import site.praytogether.pray_together.domain.auth.model.RefreshToken;
 import site.praytogether.pray_together.domain.auth.repository.RefreshTokenRepository;
-import site.praytogether.pray_together.domain.member.service.MemberService;
+import site.praytogether.pray_together.domain.member.model.Member;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
   private final RefreshTokenRepository refreshTokenRepository;
-  private final MemberService memberService;
 
-  public void save(Long memberId, String token, Instant expiredTime) {
+  public void save(Member member, String token, Instant expiredTime) {
     RefreshToken refreshToken =
         refreshTokenRepository
-            .findByMemberId(memberId)
-            .orElseGet(
-                () ->
-                    RefreshToken.create(
-                        memberService.getRefOrThrow(memberId), token, expiredTime));
+            .findByMemberId(member.getId())
+            .orElseGet(() -> RefreshToken.create(member, token, expiredTime));
 
     if (refreshToken.getId() == null) {
       refreshTokenRepository.save(refreshToken);

--- a/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
@@ -1,32 +1,53 @@
 package site.praytogether.pray_together.domain.auth.service;
 
+import java.time.Instant;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import site.praytogether.pray_together.domain.auth.cache.RefreshTokenCache;
+import org.springframework.transaction.annotation.Transactional;
 import site.praytogether.pray_together.domain.auth.exception.RefreshTokenNotFoundException;
+import site.praytogether.pray_together.domain.auth.model.RefreshToken;
+import site.praytogether.pray_together.domain.auth.repository.RefreshTokenRepository;
+import site.praytogether.pray_together.domain.member.service.MemberService;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
-  private final RefreshTokenCache cache;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final MemberService memberService;
 
-  public void save(String key, String token) {
-    cache.save(key, token);
+  public void save(Long memberId, String token, Instant expiredTime) {
+    RefreshToken refreshToken =
+        refreshTokenRepository
+            .findByMemberId(memberId)
+            .orElseGet(
+                () ->
+                    RefreshToken.create(
+                        memberService.getRefOrThrow(memberId), token, expiredTime));
+
+    if (refreshToken.getId() == null) {
+      refreshTokenRepository.save(refreshToken);
+      return;
+    }
+
+    refreshToken.updateToken(token, expiredTime);
   }
 
-  public String get(String key) {
-    return cache.get(key);
+  public RefreshToken get(Long memberId) {
+    return refreshTokenRepository
+        .findByMemberId(memberId)
+        .orElseThrow(() -> new RefreshTokenNotFoundException(memberId));
   }
 
-  public String delete(String key) {
-    return cache.delete(key);
+  @Transactional
+  public void delete(Long memberId) {
+    refreshTokenRepository.deleteByMemberId(memberId);
   }
 
-  public void validateRefreshTokenExist(String memberId, String refresh) {
-    String cachedRefresh = cache.get(memberId);
-    if (Objects.equals(refresh, cachedRefresh) == false) {
-      throw new RefreshTokenNotFoundException(Long.valueOf(memberId));
+  public void validateRefreshTokenExist(Long memberId, String refresh) {
+    RefreshToken storedRefreshToken = get(memberId);
+    if (Objects.equals(refresh, storedRefreshToken.getToken()) == false) {
+      throw new RefreshTokenNotFoundException(memberId);
     }
   }
 }

--- a/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/site/praytogether/pray_together/domain/auth/service/RefreshTokenService.java
@@ -39,13 +39,19 @@ public class RefreshTokenService {
         .orElseThrow(() -> new RefreshTokenNotFoundException(memberId));
   }
 
-  @Transactional
   public void delete(Long memberId) {
     refreshTokenRepository.deleteByMemberId(memberId);
   }
 
   public void validateRefreshTokenExist(Long memberId, String refresh) {
     RefreshToken storedRefreshToken = get(memberId);
+
+    // 만료된 토큰이면 삭제 후 예외 발생
+    if (storedRefreshToken.getExpiredTime().isBefore(Instant.now())) {
+      delete(memberId);
+      throw new RefreshTokenNotFoundException(memberId);
+    }
+
     if (Objects.equals(refresh, storedRefreshToken.getToken()) == false) {
       throw new RefreshTokenNotFoundException(memberId);
     }

--- a/src/main/java/site/praytogether/pray_together/security/PasswordEncoderConfig.java
+++ b/src/main/java/site/praytogether/pray_together/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package site.praytogether.pray_together.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/site/praytogether/pray_together/security/SecurityConfig.java
+++ b/src/main/java/site/praytogether/pray_together/security/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import site.praytogether.pray_together.domain.auth.service.RefreshTokenService;
+import site.praytogether.pray_together.domain.member.service.MemberService;
 import site.praytogether.pray_together.security.filter.JwtAuthFilter;
 import site.praytogether.pray_together.security.filter.JwtLogoutFilter;
 import site.praytogether.pray_together.security.filter.JwtValidationFilter;
@@ -28,6 +29,7 @@ public class SecurityConfig {
 
   private final ObjectMapper objectMapper;
   private final RefreshTokenService refreshTokenService;
+  private final MemberService memberService;
   private final JwtService jwtService;
   private final AuthenticationEntryPoint authenticationEntryPoint;
 
@@ -45,7 +47,8 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterBefore(new JwtLogoutFilter(refreshTokenService), LogoutFilter.class)
         .addFilterBefore(
-            new JwtAuthFilter(authenticationManager, objectMapper, refreshTokenService, jwtService),
+            new JwtAuthFilter(
+                authenticationManager, objectMapper, refreshTokenService, memberService, jwtService),
             JwtLogoutFilter.class)
         .addFilterBefore(
             new JwtValidationFilter(jwtService, authenticationEntryPoint), JwtAuthFilter.class)
@@ -59,10 +62,5 @@ public class SecurityConfig {
   @Bean
   AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
     return config.getAuthenticationManager();
-  }
-
-  @Bean
-  PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
   }
 }

--- a/src/main/java/site/praytogether/pray_together/security/filter/JwtAuthFilter.java
+++ b/src/main/java/site/praytogether/pray_together/security/filter/JwtAuthFilter.java
@@ -87,7 +87,8 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
     PrayTogetherPrincipal principal = (PrayTogetherPrincipal) authentication.getPrincipal();
     String accessToken = jwtService.issueAccessToken(principal);
     String refreshToken = jwtService.issueRefreshToken(principal);
-    refreshTokenService.save(String.valueOf(principal.getId()), refreshToken);
+    refreshTokenService.save(
+        principal.getId(), refreshToken, jwtService.extractExpiration(refreshToken));
 
     LoginResponse loginResponse =
         LoginResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build();

--- a/src/main/java/site/praytogether/pray_together/security/filter/JwtAuthFilter.java
+++ b/src/main/java/site/praytogether/pray_together/security/filter/JwtAuthFilter.java
@@ -23,6 +23,7 @@ import site.praytogether.pray_together.domain.auth.dto.LoginRequest;
 import site.praytogether.pray_together.domain.auth.dto.LoginResponse;
 import site.praytogether.pray_together.domain.auth.model.PrayTogetherPrincipal;
 import site.praytogether.pray_together.domain.auth.service.RefreshTokenService;
+import site.praytogether.pray_together.domain.member.service.MemberService;
 import site.praytogether.pray_together.exception.ExceptionResponse;
 import site.praytogether.pray_together.security.service.JwtService;
 
@@ -31,6 +32,7 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
   private final AuthenticationManager authenticationManager;
   private final ObjectMapper objectMapper;
   private final RefreshTokenService refreshTokenService;
+  private final MemberService memberService;
   private final String LOGIN_URL = "/api/v1/auth/login";
   private final JwtService jwtService;
 
@@ -38,10 +40,12 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
       AuthenticationManager authenticationManager,
       ObjectMapper objectMapper,
       RefreshTokenService refreshTokenService,
+      MemberService memberService,
       JwtService jwtService) {
     this.authenticationManager = authenticationManager;
     this.objectMapper = objectMapper;
     this.refreshTokenService = refreshTokenService;
+    this.memberService = memberService;
     this.jwtService = jwtService;
     setFilterProcessesUrl(LOGIN_URL);
   }
@@ -88,7 +92,9 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
     String accessToken = jwtService.issueAccessToken(principal);
     String refreshToken = jwtService.issueRefreshToken(principal);
     refreshTokenService.save(
-        principal.getId(), refreshToken, jwtService.extractExpiration(refreshToken));
+        memberService.getRefOrThrow(principal.getId()),
+        refreshToken,
+        jwtService.extractExpiration(refreshToken));
 
     LoginResponse loginResponse =
         LoginResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build();

--- a/src/main/java/site/praytogether/pray_together/security/filter/JwtLogoutFilter.java
+++ b/src/main/java/site/praytogether/pray_together/security/filter/JwtLogoutFilter.java
@@ -35,7 +35,7 @@ public class JwtLogoutFilter extends OncePerRequestFilter {
     logger.info("로그아웃 인증 정보 = {}", authentication);
     if (authentication == null) return;
     PrayTogetherPrincipal principal = (PrayTogetherPrincipal) authentication.getPrincipal();
-    refreshTokenService.delete(String.valueOf(principal.getId()));
+    refreshTokenService.delete(principal.getId());
 
     response.setStatus(HttpServletResponse.SC_NO_CONTENT);
   }

--- a/src/main/java/site/praytogether/pray_together/security/service/JwtService.java
+++ b/src/main/java/site/praytogether/pray_together/security/service/JwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 import javax.crypto.SecretKey;
@@ -73,6 +74,10 @@ public class JwtService {
 
   public Long extractMemberId(String token) {
     return Long.valueOf(extractAllClaims(token).getSubject());
+  }
+
+  public Instant extractExpiration(String token) {
+    return extractAllClaims(token).getExpiration().toInstant();
   }
 
   private Claims extractAllClaims(String token) {


### PR DESCRIPTION
# 📝 어떤 변경인가요?

  ## 주요 변경 사항
  - RefreshToken 저장소를 Redis 캐시에서 RDB로 변경
  - RefreshToken 엔티티 및 리포지토리 추가
  - RefreshToken 저장 시 만료 시간 정보 포함
  - RrefreshToken 재발급시, 만료된 Refresh 삭제 후, Not Found 예외 발생

  ## 주요 추가/수정 항목
  - RefreshToken 엔티티 추가 (JPA)
  - RefreshTokenRepository 인터페이스 추가
  - RefreshTokenService 로직을 RDB 기반으로 재구현
  - JwtService에 토큰 만료 시간 추출 메서드 추가
  - AuthApplicationService에 @Transactional 어노테이션 추가

  # 🎯 변경의 목적은 무엇인가요?

  ## 배경
  RefreshToken을 Local 캐시에 저장하고 있어, 서버 재배포시 사용자가 재로그인해야 하는 문제가 있었음. 이를 해결 하기 위하여 RDB에 refresh token을 저장

  ## 목적
  - 토큰 데이터의 영속성 보장 및 안정성 향상
  - Member 삭제 시 RefreshToken 자동 삭제 (CASCADE)

  # 🔧 어떻게 변경되었나요?

  ## 새로운 파일
  - `RefreshToken.java` - RefreshToken JPA 엔티티 (Member와 OneToOne 관계)
  - `RefreshTokenRepository.java` - RefreshToken JPA 리포지토리

  ## 수정된 파일

  | 파일 | 변경 사항 |
  |------|---------|
  | RefreshTokenService | Redis Cache 대신 JPA Repository 사용, 토큰 저장 시 만료시간 저장 |
  | AuthApplicationService | @Transactional 추가, RefreshToken 저장 시 만료시간 전달 |
  | JwtService | extractExpiration() 메서드 추가 |
  | JwtAuthFilter | RefreshToken 저장 시 만료시간 전달 |
  | JwtLogoutFilter | memberId 타입 String → Long 변경 |

  ## 기술적 상세

  ### 1. RefreshToken 엔티티 설계
  - Member와 OneToOne 관계 설정
  - @OnDelete(CASCADE)로 Member 삭제 시 자동 삭제
  - token, expiredTime 필드로 토큰 정보 관리
  - updateToken() 메서드로 기존 토큰 갱신

  ### 2. 저장소 변경 로직
  - RefreshTokenService.save(): 기존 토큰이 있으면 update, 없으면 insert
  - 캐시 기반 String 키 → RDB 기반 Long memberId로 변경
  - JwtService에서 토큰 만료시간 추출하여 DB에 저장

  ### 3. 트랜잭션 관리
  - AuthApplicationService에 @Transactional 추가
  - RefreshTokenService.delete()에 @Transactional 추가


  ⚠️ 특이 사항

  📋 배포 시 주의사항

  데이터베이스 마이그레이션 필수

  1. refresh_token 테이블이 자동 생성되는지 확인 (JPA DDL 설정 확인)
  2. 또는 수동으로 마이그레이션 스크립트 실행:
  CREATE TABLE refresh_token (
      id BIGSERIAL PRIMARY KEY,
      member_id BIGINT NOT NULL UNIQUE,
      token VARCHAR(512) NOT NULL,
      expired_time TIMESTAMP(3) WITH TIME ZONE NOT NULL,
      created_at TIMESTAMP(3) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
      updated_at TIMESTAMP(3) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
      CONSTRAINT fk_refresh_token_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
  );

  CREATE INDEX idx_refresh_token_member_id ON refresh_token(member_id);
